### PR TITLE
V2.6 book series

### DIFF
--- a/stanford-sw/src/edu/stanford/FormatUtils.java
+++ b/stanford-sw/src/edu/stanford/FormatUtils.java
@@ -234,8 +234,7 @@ public class FormatUtils {
 		if (ch != '\u0000')
 			switch (ch) {
 				case 'm': // monographic series
-					return Format.BOOK_SERIES.toString();  // FIXME: temporary format
-//					return Format.BOOK.toString();
+					return Format.BOOK.toString();
 				case 'n':
 					return Format.NEWSPAPER.toString();
 				case 'p':
@@ -255,8 +254,7 @@ public class FormatUtils {
 		if (ch != '\u0000')
 			switch (ch) {
 				case 'm': // monographic series
-					return Format.BOOK_SERIES.toString();  // FIXME: temporary format
-//					return Format.BOOK.toString();
+					return Format.BOOK.toString();
 				case 'n':
 					return Format.NEWSPAPER.toString();
 				case 'p':

--- a/stanford-sw/src/edu/stanford/StanfordIndexer.java
+++ b/stanford-sw/src/edu/stanford/StanfordIndexer.java
@@ -352,13 +352,7 @@ public class StanfordIndexer extends org.solrmarc.index.SolrIndexer
 			// does updating/integrating resource need to be revised based on SFX url?
 			if (sfxUrls.size() > 0)
 			{
-				String bookSerVal = Format.BOOK_SERIES.toString();
-				if (main_formats.contains(bookSerVal))
-				{
-					main_formats.remove(bookSerVal);
-					main_formats.add(journalVal);
-				}
-				else if (main_formats.contains(updatingDbVal))
+				if (main_formats.contains(updatingDbVal))
 				{
 					main_formats.remove(updatingDbVal);
 					main_formats.add(journalVal);
@@ -485,7 +479,7 @@ public class StanfordIndexer extends org.solrmarc.index.SolrIndexer
 	{
 		String leaderStr = record.getLeader().marshal();
 		char leaderChar07 = leaderStr.charAt(7);
-		
+
 		Set<String> resultSet = new HashSet<String>();
 
 		// look for thesis by existence of 502 field
@@ -505,9 +499,9 @@ public class StanfordIndexer extends org.solrmarc.index.SolrIndexer
 				}
 			}
 		}
-		
-		/** Based upon SW-1056, added the following to the algorithm to determine if something is a conference proceeding: 
-		 *  Leader/07 = 'm' or 's' and 008/29 = '1' 
+
+		/** Based upon SW-1056, added the following to the algorithm to determine if something is a conference proceeding:
+		 *  Leader/07 = 'm' or 's' and 008/29 = '1'
 		 **/
 		if (leaderChar07 == 'm' || leaderChar07 == 's') {
 			// check if it's a conference proceeding based on 008 char 29

--- a/stanford-sw/src/edu/stanford/enumValues/Format.java
+++ b/stanford-sw/src/edu/stanford/enumValues/Format.java
@@ -6,8 +6,6 @@ package edu.stanford.enumValues;
  */
 public enum Format {
 	BOOK,
-	/** @deprecated */
-	BOOK_SERIES, // Possibly temporary
 	COMPUTER_FILE,
 	DATABASE_A_Z,
 	DATASET,
@@ -34,8 +32,6 @@ public enum Format {
 	@Override
 	public String toString() {
 		switch (this) {
-			case BOOK_SERIES:
-				return "Book series";
 			case COMPUTER_FILE:
 				return "Software/Multimedia";
 			case DATABASE_A_Z:

--- a/stanford-sw/test/src/edu/stanford/FormatMainTests.java
+++ b/stanford-sw/test/src/edu/stanford/FormatMainTests.java
@@ -68,12 +68,7 @@ public class FormatMainTests extends AbstractStanfordTest
 		solrFldMapTest.assertSolrFldValue(testFilePath, "leader06a07m", fldName, bookVal);
 		solrFldMapTest.assertSolrFldValue(testFilePath, "leader06t07a", fldName, bookVal);
 
-		// monographic series
-// FIXME:  temporary for format redo
-//		solrFldMapTest.assertSolrFldValue(testFilePath, "leader07s00821m", fldName, fldVal);
-//		solrFldMapTest.assertSolrFldValue(testFilePath, "5987319", fldName, fldVal);
-//		solrFldMapTest.assertSolrFldValue(testFilePath, "5598989", fldName, fldVal);
-//		solrFldMapTest.assertSolrFldValue(testFilePath, "223344", fldName, fldVal);
+		// monographic series (?)
 		solrFldMapTest.assertSolrFldValue(testFilePath, "5666387", fldName, bookVal);
 		solrFldMapTest.assertSolrFldValue(testFilePath, "666", fldName, bookVal);
 
@@ -82,13 +77,13 @@ public class FormatMainTests extends AbstractStanfordTest
 	}
 
 	/**
-	 * if a continuing monographic resource (a book series) has an SFX link,
-	 * then it should be format Journal.
-	 */
+     * if a continuing monographic resource (a book series) has an SFX link,
+     * then it should be format Journal.
+     */
 @Test
-	public final void testBookSeriesAsJournal()
+	public final void testBookSeriesAsBook()
 	{
-		String bookSeriesVal = Format.BOOK_SERIES.toString();
+		String bookSeriesVal = Format.BOOK.toString();
 		// based on 9343812 - SFX link
 		Record record = factory.newRecord();
 		record.setLeader(factory.newLeader("01937cas a2200433 a 4500"));
@@ -96,7 +91,7 @@ public class FormatMainTests extends AbstractStanfordTest
 		record.addVariableField(cf008);
 		record.addVariableField(df956sfx);
 		solrFldMapTest.assertSolrFldHasNumValues(record, fldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, fldName, journalVal);
+		solrFldMapTest.assertSolrFldValue(record, fldName, bookSeriesVal);
 
 		// based on 9138750 - no SFX link
 		record = factory.newRecord();
@@ -111,7 +106,7 @@ public class FormatMainTests extends AbstractStanfordTest
 		solrFldMapTest.assertSolrFldValue(testFilePath, "5987319", fldName, bookSeriesVal);
 		solrFldMapTest.assertSolrFldValue(testFilePath, "5598989", fldName, bookSeriesVal);
 		solrFldMapTest.assertSolrFldValue(testFilePath, "223344", fldName, bookSeriesVal);
-	}
+    }
 
 	/**
 	 * Computer File format tests
@@ -183,7 +178,7 @@ public class FormatMainTests extends AbstractStanfordTest
 	    df650.addSubfield(factory.newSubfield('v', "Congresses."));
 	    rec.addVariableField(df650);
 	    solrFldMapTest.assertSolrFldHasNoValue(rec, fldName, fldVal);
-	    
+
 		// test 600|v Congresses
 		rec = factory.newRecord();
 	    rec.setLeader(factory.newLeader("04473caa a2200313Ia 4500"));


### PR DESCRIPTION
splitting out the book-series format_main tweak from the physics library tweak.  (My bad they were put together in the first place).

Slight difference in the tests -- keeping the more thorough tests that were written, but the result is now Book, not Book series.

@lmcglohon 
