### PR TITLE
V2.6 fix crez scripts

### DIFF
--- a/stanford-sw/scripts/indexManyNightlyNoEmail.sh
+++ b/stanford-sw/scripts/indexManyNightlyNoEmail.sh
@@ -1,27 +1,15 @@
 #! /bin/bash
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140308
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140309
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140310
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140311
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140312
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140313
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140314
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140315
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140316
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140317
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140318
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140319
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140320
+/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140611
+/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140612
+/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140613
+/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh 140614
 # last one should do commit before crez processing
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrez.sh 140321
+/home/blacklight/solrmarc-sw/stanford-sw/scripts/indexNightlyNoEmailNoCrez.sh 140615
 
 # include latest course reserves data IFF it's not done with above scripts
-JRUBY_OPTS="--1.9"
-export JRUBY_OPTS
 LANG="en_US.UTF-8"
 export LANG
-
-(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && source ./.rvmrc && ./bin/index_latest_no_email.sh -s prod )
+(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/index_latest_no_email.sh -s prod )
 
 echo "!!! RUN GDOR, SEARCHWORKS TESTS before putting index into production !!!"
 echo "!!! CHGRP before putting index into production !!!"

--- a/stanford-sw/scripts/indexNightlyNoEmail.sh
+++ b/stanford-sw/scripts/indexNightlyNoEmail.sh
@@ -44,11 +44,9 @@ nohup java -Xmx1g -Xms256m $DEL_ARG -Dsolr.commit_at_end="true" -cp $CP -jar $SI
 #$SOLRMARC_BASEDIR/stanford-sw/scripts/grep_and_email_tomcat_log.sh
 
 # include latest course reserves data
-JRUBY_OPTS="--1.9"
-export JRUBY_OPTS
 LANG="en_US.UTF-8"
 export LANG
 
-(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && source ./.rvmrc && ./bin/pull_and_index_latest -s prod )
+(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/pull_and_index_latest -s prod )
 
 exit 0

--- a/stanford-sw/scripts/indexNightlyNoEmailNoCrez.sh
+++ b/stanford-sw/scripts/indexNightlyNoEmailNoCrez.sh
@@ -44,11 +44,9 @@ nohup java -Xmx1g -Xms256m $DEL_ARG -Dsolr.commit_at_end="true" -cp $CP -jar $SI
 #$SOLRMARC_BASEDIR/stanford-sw/scripts/grep_and_email_tomcat_log.sh
 
 # include latest course reserves data
-#JRUBY_OPTS="--1.9"
-#export JRUBY_OPTS
 #LANG="en_US.UTF-8"
 #export LANG
 
-#(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && source ./.rvmrc && ./bin/pull_and_index_latest -s prod )
+#(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/pull_and_index_latest -s prod )
 
 exit 0

--- a/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh
+++ b/stanford-sw/scripts/indexNightlyNoEmailNoCrezNoCommit.sh
@@ -45,11 +45,8 @@ nohup java -Xmx1g -Xms256m $DEL_ARG -cp $CP -jar $SITE_JAR $REC_FNAME &>$LOG_FIL
 #$SOLRMARC_BASEDIR/stanford-sw/scripts/grep_and_email_tomcat_log.sh
 
 # include latest course reserves data
-#JRUBY_OPTS="--1.9"
-#export JRUBY_OPTS
 #LANG="en_US.UTF-8"
 #export LANG
-
-#(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && source ./.rvmrc && ./bin/pull_and_index_latest -s prod )
+#(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/pull_and_index_latest -s prod )
 
 exit 0

--- a/stanford-sw/scripts/pullThenIndexBodoniHourly.sh
+++ b/stanford-sw/scripts/pullThenIndexBodoniHourly.sh
@@ -51,11 +51,9 @@ mail -s 'pullThenIndexSirsiIncr.sh partday output' searchworks-reports@lists.sta
 $SOLRMARC_BASEDIR/stanford-sw/scripts/grep_and_email_tomcat_log.sh
 
 # include latest course reserves data
-JRUBY_OPTS="--1.9"
-export JRUBY_OPTS
 LANG="en_US.UTF-8"
 export LANG
 
-(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && source ./.rvmrc && ./bin/pull_and_index_latest -s prod)
+(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/pull_and_index_latest -s prod)
 
 exit 0

--- a/stanford-sw/scripts/pullThenIndexBodoniHourlyNoEmail.sh
+++ b/stanford-sw/scripts/pullThenIndexBodoniHourlyNoEmail.sh
@@ -51,11 +51,9 @@ nohup java -Xmx1g -Xms256m $DEL_ARG -Dsolr.commit_at_end="true" -cp $CP -jar $SI
 #$SOLRMARC_BASEDIR/stanford-sw/scripts/grep_and_email_tomcat_log.sh
 
 # include latest course reserves data
-JRUBY_OPTS="--1.9"
-export JRUBY_OPTS
 LANG="en_US.UTF-8"
 export LANG
 
-(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && source ./.rvmrc && ./bin/pull_and_index_latest_no_email -s prod)
+(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/pull_and_index_latest_no_email -s prod)
 
 exit 0

--- a/stanford-sw/scripts/pullThenIndexBodoniHourlyNoEmailNoCrez.sh
+++ b/stanford-sw/scripts/pullThenIndexBodoniHourlyNoEmailNoCrez.sh
@@ -51,11 +51,9 @@ nohup java -Xmx1g -Xms256m $DEL_ARG -Dsolr.commit_at_end="true" -cp $CP -jar $SI
 #$SOLRMARC_BASEDIR/stanford-sw/scripts/grep_and_email_tomcat_log.sh
 
 # include latest course reserves data
-#JRUBY_OPTS="--1.9"
-#export JRUBY_OPTS
 #LANG="en_US.UTF-8"
 #export LANG
 
-#(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && source ./.rvmrc && ./bin/index_latest_no_email.sh -s prod)
+#(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/index_latest_no_email.sh -s prod)
 
 exit 0

--- a/stanford-sw/scripts/pullThenIndexBodoniHourlyNoEmailNoPullCrez.sh
+++ b/stanford-sw/scripts/pullThenIndexBodoniHourlyNoEmailNoPullCrez.sh
@@ -51,11 +51,9 @@ nohup java -Xmx1g -Xms256m $DEL_ARG -Dsolr.commit_at_end="true" -cp $CP -jar $SI
 #$SOLRMARC_BASEDIR/stanford-sw/scripts/grep_and_email_tomcat_log.sh
 
 # include latest course reserves data
-JRUBY_OPTS="--1.9"
-export JRUBY_OPTS
 LANG="en_US.UTF-8"
 export LANG
 
-(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && source ./.rvmrc && ./bin/index_latest_no_email.sh -s prod)
+(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/index_latest_no_email.sh -s prod)
 
 exit 0

--- a/stanford-sw/scripts/pullThenIndexBodoniManyNightlyNoEmail.sh
+++ b/stanford-sw/scripts/pullThenIndexBodoniManyNightlyNoEmail.sh
@@ -1,17 +1,17 @@
 #! /bin/bash
 
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/pullThenIndexBodoniNightlyNoEmailNoCrezNoCommit.sh 140317
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/pullThenIndexBodoniNightlyNoEmailNoCrezNoCommit.sh 140318
+/home/blacklight/solrmarc-sw/stanford-sw/scripts/pullThenIndexBodoniNightlyNoEmailNoCrezNoCommit.sh 140611
+/home/blacklight/solrmarc-sw/stanford-sw/scripts/pullThenIndexBodoniNightlyNoEmailNoCrezNoCommit.sh 140612
+/home/blacklight/solrmarc-sw/stanford-sw/scripts/pullThenIndexBodoniNightlyNoEmailNoCrezNoCommit.sh 140613
+/home/blacklight/solrmarc-sw/stanford-sw/scripts/pullThenIndexBodoniNightlyNoEmailNoCrezNoCommit.sh 140614
 # last one should do commit before crez processing
-/home/blacklight/solrmarc-sw/stanford-sw/scripts/pullThenIndexBodoniNightlyNoEmailNoCrez.sh 130319
+/home/blacklight/solrmarc-sw/stanford-sw/scripts/pullThenIndexBodoniNightlyNoEmailNoCrez.sh 140615
 
 # include latest course reserves data IFF it's not done with above scripts
-JRUBY_OPTS="--1.9"
-export JRUBY_OPTS
 LANG="en_US.UTF-8"
 export LANG
 
-(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && source ./.rvmrc && ./bin/index_latest_no_email.sh -s prod )
+(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/index_latest_no_email.sh -s prod )
 
 echo "!!! RUN GDOR, SEARCHWORKS TESTS before putting index into production !!!"
 echo "!!! CHGRP before putting index into production !!!"

--- a/stanford-sw/scripts/pullThenIndexBodoniNightly.sh
+++ b/stanford-sw/scripts/pullThenIndexBodoniNightly.sh
@@ -59,11 +59,9 @@ mail -s 'pullThenIndexSirsiIncr.sh output' searchworks-reports@lists.stanford.ed
 $SOLRMARC_BASEDIR/stanford-sw/scripts/grep_and_email_tomcat_log.sh
 
 # include latest course reserves data
-JRUBY_OPTS="--1.9"
-export JRUBY_OPTS
 LANG="en_US.UTF-8"
 export LANG
 
-(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && source ./.rvmrc && ./bin/index_latest.sh -s prod)
+(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/index_latest.sh -s prod)
 
 exit 0

--- a/stanford-sw/scripts/pullThenIndexBodoniNightlyNoEmailNoCrez.sh
+++ b/stanford-sw/scripts/pullThenIndexBodoniNightlyNoEmailNoCrez.sh
@@ -59,11 +59,9 @@ nohup java -Xmx1g -Xms256m $DEL_ARG -Dsolr.commit_at_end="true" -cp $CP -jar $SI
 #$SOLRMARC_BASEDIR/stanford-sw/scripts/grep_and_email_tomcat_log.sh
 
 # include latest course reserves data
-#JRUBY_OPTS="--1.9"
-#export JRUBY_OPTS
 #LANG="en_US.UTF-8"
 #export LANG
 
-#(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && source ./.rvmrc && ./bin/index_latest_no_email.sh -s prod)
+#(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/index_latest_no_email.sh -s prod)
 
 exit 0

--- a/stanford-sw/scripts/pullThenIndexBodoniNightlyNoEmailNoCrezNoCommit.sh
+++ b/stanford-sw/scripts/pullThenIndexBodoniNightlyNoEmailNoCrezNoCommit.sh
@@ -60,11 +60,9 @@ nohup java -Xmx1g -Xms256m $DEL_ARG -cp $CP -jar $SITE_JAR $REC_FNAME &>$LOG_FIL
 #$SOLRMARC_BASEDIR/stanford-sw/scripts/grep_and_email_tomcat_log.sh
 
 # include latest course reserves data
-#JRUBY_OPTS="--1.9"
-#export JRUBY_OPTS
 #LANG="en_US.UTF-8"
 #export LANG
 
-#(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && source ./.rvmrc && ./bin/index_latest_no_email.sh -s prod)
+#(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/index_latest_no_email.sh -s prod)
 
 exit 0

--- a/stanford-sw/scripts/pullThenIndexMorisonHourlyNoEmail.sh
+++ b/stanford-sw/scripts/pullThenIndexMorisonHourlyNoEmail.sh
@@ -51,11 +51,9 @@ nohup java -Xmx1g -Xms256m $DEL_ARG -Dsolr.commit_at_end="true" -cp $CP -jar $SI
 #$SOLRMARC_BASEDIR/stanford-sw/scripts/grep_and_email_tomcat_log.sh
 
 # include latest course reserves data
-JRUBY_OPTS="--1.9"
-export JRUBY_OPTS
 LANG="en_US.UTF-8"
 export LANG
 
-(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && source ./.rvmrc && ./bin/pull_and_index_latest_no_email -s prod)
+(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/pull_and_index_latest_no_email -s prod)
 
 exit 0

--- a/stanford-sw/scripts/pullThenIndexMorisonHourlyNoEmailNoCrez.sh
+++ b/stanford-sw/scripts/pullThenIndexMorisonHourlyNoEmailNoCrez.sh
@@ -51,11 +51,9 @@ nohup java -Xmx1g -Xms256m $DEL_ARG -Dsolr.commit_at_end="true" -cp $CP -jar $SI
 #$SOLRMARC_BASEDIR/stanford-sw/scripts/grep_and_email_tomcat_log.sh
 
 # include latest course reserves data
-#JRUBY_OPTS="--1.9"
-#export JRUBY_OPTS
 #LANG="en_US.UTF-8"
 #export LANG
 
-#(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && source ./.rvmrc && ./bin/index_latest_no_email.sh -s prod)
+#(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/index_latest_no_email.sh -s prod)
 
 exit 0

--- a/stanford-sw/scripts/pullThenIndexMorisonNightlyNoEmailNoCrez.sh
+++ b/stanford-sw/scripts/pullThenIndexMorisonNightlyNoEmailNoCrez.sh
@@ -59,11 +59,9 @@ nohup java -Xmx1g -Xms256m $DEL_ARG -Dsolr.commit_at_end="true" -cp $CP -jar $SI
 #$SOLRMARC_BASEDIR/stanford-sw/scripts/grep_and_email_tomcat_log.sh
 
 # include latest course reserves data
-#JRUBY_OPTS="--1.9"
-#export JRUBY_OPTS
 #LANG="en_US.UTF-8"
 #export LANG
 
-#(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && source ./.rvmrc && ./bin/index_latest_no_email.sh -s prod)
+#(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/index_latest_no_email.sh -s prod)
 
 exit 0

--- a/stanford-sw/scripts/pullThenIndexSirsiIncr.sh
+++ b/stanford-sw/scripts/pullThenIndexSirsiIncr.sh
@@ -60,11 +60,9 @@ mail -s 'pullThenIndexSirsiIncr.sh output' searchworks-reports@lists.stanford.ed
 $SOLRMARC_BASEDIR/stanford-sw/scripts/grep_and_email_tomcat_log.sh
 
 # include latest course reserves data
-JRUBY_OPTS="--1.9"
-export JRUBY_OPTS
 LANG="en_US.UTF-8"
 export LANG
 
-(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && source ./.rvmrc && ./bin/index_latest_no_email.sh -s prod)
+(source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/index_latest_no_email.sh -s prod)
 
 exit 0


### PR DESCRIPTION
sync this up with master branch -- crez no longer uses rvmrc nor does it need ruby 1.9 mode to be explicitly set.

@lmcglohon 
