### PR TITLE
Remove DRMC (Rumsey Maps) as a valid library

### DIFF
--- a/stanford-sw/src/edu/stanford/Item.java
+++ b/stanford-sw/src/edu/stanford/Item.java
@@ -92,6 +92,8 @@ public class Item {
 		if (StanfordIndexer.SKIPPED_LOCS.contains(currLoc)
 					|| StanfordIndexer.SKIPPED_LOCS.contains(homeLoc)
 					|| itemType.equals("EDI-REMOVE")
+					// Temporarily skip RUMSEYMAP Library # David Rumsey Map Center
+					|| (library.equals("RUMSEYMAP"))
 					// SW-849 skip PHYSICS items that aren't location PHYSTEMP
 					|| (library.equals("PHYSICS") && (!homeLoc.equals("PHYSTEMP") && !currLoc.equals("PHYSTEMP"))))
 			shouldBeSkipped = true;

--- a/stanford-sw/test/data/itemSkippedTests.xml
+++ b/stanford-sw/test/data/itemSkippedTests.xml
@@ -147,4 +147,30 @@
             <subfield code="t">STKS-MONO</subfield>
         </datafield>
     </record>
+     <!-- Temporarily skip  RUMSEYMAP library for indexing items-->
+    <record>
+        <leader>01149nam a22002891  4500</leader>
+        <controlfield tag="001">akeepOneTemp</controlfield>
+        <controlfield tag="008">840514s1962    enk      b    000 0 eng  </controlfield>
+        <datafield tag="245" ind1="1" ind2="0">
+            <subfield code="a">keep one temp, skip one temp</subfield>
+        </datafield>
+        <datafield tag="999" ind1=" " ind2=" ">
+            <subfield code="a">KEEPTEMP</subfield>
+            <subfield code="w">ASIS</subfield>
+            <subfield code="c">1</subfield>
+            <subfield code="i">KEEPTEMP</subfield>
+            <subfield code="l">STACKS</subfield>
+            <subfield code="m">GREEN</subfield>
+            <subfield code="t">STKS</subfield>
+        </datafield>
+        <datafield tag="999" ind1=" " ind2=" ">
+            <subfield code="a">SKIPTEMP</subfield>
+            <subfield code="w">ASIS</subfield>
+            <subfield code="c">2</subfield>
+            <subfield code="i">SKIPTEMP</subfield>
+            <subfield code="m">RUMSEYMAP</subfield>
+            <subfield code="t">STKS-MONO</subfield>
+        </datafield>
+    </record>
 </collection>

--- a/stanford-sw/test/src/edu/stanford/ItemInfoTests.java
+++ b/stanford-sw/test/src/edu/stanford/ItemInfoTests.java
@@ -58,7 +58,6 @@ public class ItemInfoTests extends AbstractStanfordTest {
 	    assertSingleResult("6676531", fldName, "\"East Asia\"");
 	    assertSingleResult("10421123", fldName, "Lathrop");
 	    assertSingleResult("2797608", fldName, "\"Media & Microtext Center\"");
-	    assertSingleResult("2797609", fldName, "\"David Rumsey Map Center\"");
 
 	    // hoover tests are a separate method below
 
@@ -139,6 +138,9 @@ public class ItemInfoTests extends AbstractStanfordTest {
 
 	    // INDEX-168 Meyer no longer exists
 	    assertZeroResults(fldName, "\"MEYER\"");
+
+		// Skip RUMSEYMAP library until UI is ready
+	    assertZeroResults(fldName, "\"RUMSEYMAP\"");
 	}
 
 	/**

--- a/stanford-sw/test/src/edu/stanford/ItemSkippedTests.java
+++ b/stanford-sw/test/src/edu/stanford/ItemSkippedTests.java
@@ -78,6 +78,23 @@ public class ItemSkippedTests extends AbstractStanfordTest
 
 	    id = "keepOne";
 	    solrFldMapTest.assertSolrFldHasNoValue(testFilePath, id, fldName, fldVal);
+
+	    id = "keepOneTemp";
+		callnum = "KEEPTEMP";
+		shelfkey = edu.stanford.CallNumUtils.getShelfKey(callnum, CallNumberType.OTHER, id).toLowerCase();
+		reversekey = org.solrmarc.tools.CallNumUtils.getReverseShelfKey(shelfkey).toLowerCase();
+		volSort = edu.stanford.CallNumUtils.getVolumeSortCallnum(callnum, callnum, shelfkey, CallNumberType.OTHER, !isSerial, id);
+		fldVal = "KEEPTEMP -|- GREEN -|- STACKS" + SEP + SEP + "STKS" + SEP + callnum + SEP +
+				shelfkey + SEP + reversekey + SEP + callnum + SEP + volSort + SEP + SEP + CallNumberType.OTHER;
+	    solrFldMapTest.assertSolrFldValue(testFilePath, id, fldName, fldVal);
+
+	    callnum = "SKIPTEMP";
+		shelfkey = edu.stanford.CallNumUtils.getShelfKey(callnum, CallNumberType.OTHER, id).toLowerCase();
+		reversekey = org.solrmarc.tools.CallNumUtils.getReverseShelfKey(shelfkey).toLowerCase();
+		volSort = edu.stanford.CallNumUtils.getVolumeSortCallnum(callnum, callnum, shelfkey, CallNumberType.OTHER, !isSerial, id);
+		fldVal = "SKIPTEMP -|- RUMSEYMAP -|- STACKS" + SEP + SEP + SEP + callnum + SEP +
+				shelfkey + SEP + reversekey + SEP + callnum + SEP + volSort + SEP + SEP + CallNumberType.OTHER;
+	    solrFldMapTest.assertSolrFldHasNoValue(testFilePath, id, fldName, fldVal);
 	}
 
 

--- a/stanford-sw/translation_maps/library_map.properties
+++ b/stanford-sw/translation_maps/library_map.properties
@@ -29,7 +29,6 @@ MEDIA-MTXT = Media & Microtext Center
 # MEYER = Meyer no longer exists (INDEX-168)
 MUSIC = Music
 #PHYSICS = Physics no longer exists
-RUMSEYMAP = David Rumsey Map Center
 SAL = SAL1&2 (on-campus shelving)
 SAL3 = SAL3 (off-campus storage)
 SAL-NEWARK = SAL Newark (off-campus storage)
@@ -39,3 +38,7 @@ SPEC-COLL = Special Collections
 TANNER = Philosophy (Tanner)
 
 #SUL = Stanford University Libraries
+
+# These are new libraries that need UI changes that have been put here until we have official User-friendly versions
+# and the UI is ready for them.  Once they need to be included, they should be interfiled in the alphabetic list above.
+#RUMSEYMAP = David Rumsey Map Center


### PR DESCRIPTION
and makes sure that any items with RUMSEYMAP as a library are skipped during indexing
