### PR TITLE
SW-1531 add Piano/organ roll as media type

### DIFF
--- a/stanford-sw/src/edu/stanford/FormatUtils.java
+++ b/stanford-sw/src/edu/stanford/FormatUtils.java
@@ -578,7 +578,7 @@ public class FormatUtils {
    * VIDEO_CD - 300$b or 347$b = VCD, Video CD, or VideoCD
    *
    * SW-1531 - Add piano and organ rolls as a media type
-   * Assign physical format if 338$a or 300$a contains "audio roll"
+   * Assign physical format if 338$a or 300$a contains "audio, piano, or organ roll"
 
    * @param record
    * @return String containing Physical Format enum value, or null
@@ -599,7 +599,11 @@ public class FormatUtils {
     Set<String> f338a = MarcUtils.getSubfieldDataAsSet(record, "338", "a", "");
     Set<String> f300a = MarcUtils.getSubfieldDataAsSet(record, "300", "a", "");
     if (Utils.setItemContains(f338a, "audio roll") ||
-        Utils.setItemContains(f300a, "audio roll"))
+        Utils.setItemContains(f338a, "piano roll") ||
+        Utils.setItemContains(f338a, "organ roll") ||
+        Utils.setItemContains(f300a, "audio roll") ||
+        Utils.setItemContains(f300a, "piano roll") ||
+        Utils.setItemContains(f300a, "organ roll"))
       result.add(FormatPhysical.PIANO_ORGAN_ROLL.toString());
     return result;
   }

--- a/stanford-sw/src/edu/stanford/FormatUtils.java
+++ b/stanford-sw/src/edu/stanford/FormatUtils.java
@@ -16,765 +16,779 @@ import edu.stanford.enumValues.*;
  */
 public class FormatUtils {
 
-	/**
-	 * Default Constructor: private, so it can't be instantiated by other objects
-	 */
-	private FormatUtils(){ }
+  /**
+   * Default Constructor: private, so it can't be instantiated by other objects
+   */
+  private FormatUtils(){ }
 
 
-	/**
-	 * Assign formats based on leader chars 06, 07 and chars in 008
-	 *
-	 * Algorithms for formats are currently in email  message from Vitus Tang to
-	 *  Naomi Dushay, cc Phil Schreur, Margaret Hughes, and Jennifer Vine
-	 *  dated July 23, 2008.
-	 *
-	 * @param leaderStr - the leader field, as a String
-	 * @param cf008 - the 008 field as a ControlField object
-	 * @param Set of Strings containing Format enum values per the given data
-	 */
-	static Set<String> getFormatsPerLdrAnd008(String leaderStr, ControlField cf008)
-	{
-		Set<String> result = new HashSet<String>();
+  /**
+   * Assign formats based on leader chars 06, 07 and chars in 008
+   *
+   * Algorithms for formats are currently in email  message from Vitus Tang to
+   *  Naomi Dushay, cc Phil Schreur, Margaret Hughes, and Jennifer Vine
+   *  dated July 23, 2008.
+   *
+   * @param leaderStr - the leader field, as a String
+   * @param cf008 - the 008 field as a ControlField object
+   * @param Set of Strings containing Format enum values per the given data
+   */
+  static Set<String> getFormatsPerLdrAnd008(String leaderStr, ControlField cf008)
+  {
+    Set<String> result = new HashSet<String>();
 
-		// Note: MARC21 documentation refers to char numbers that are 0 based,
-		// just like java string indexes, so char "06" is at index 6, and is
-		// the seventh character of the field
+    // Note: MARC21 documentation refers to char numbers that are 0 based,
+    // just like java string indexes, so char "06" is at index 6, and is
+    // the seventh character of the field
 
-		// assign formats based on leader chars 06, 07 and chars in 008
-		char leaderChar07 = leaderStr.charAt(7);
-		char leaderChar06 = leaderStr.charAt(6);
-		switch (leaderChar06) {
-		case 'a':
-			if (leaderChar07 == 'a' || leaderChar07 == 'm')
-				result.add(Format.BOOK.toString());
-			// INDEX-75 Move "Other" collections to Archive/Manuscript
-			// look for Leader/06 = a and Leader/07 = c
-			if (leaderChar07 == 'c')
-				result.add(Format.MANUSCRIPT_ARCHIVE.toString());
-			break;
-		case 'b':
-		case 'p':
-			result.add(Format.MANUSCRIPT_ARCHIVE.toString());
-			break;
-		case 'c':
-		case 'd':
-			result.add(Format.MUSIC_SCORE.toString());
-			break;
-		case 'e':
-		case 'f':
-			result.add(Format.MAP.toString());
-			break;
-		case 'g':
-			// INDEX-120 Additional criteria for video and image
-			// VIDEO: 008/33 = f m v [I would also include the values |, blank, and any numerals]
-			// IMAGE: 008/33 = a c i k l n o p s t [some of these should not be used with Leader/06 = g but let's assume the worst]
-			// 008 field, char 33 (count starts at 0)
-			if (cf008 != null)
-			{
-				if (cf008.find("^.{33}[ |0-9fmv]"))
-					result.add(Format.VIDEO.toString());
-				else if (cf008.find("^.{33}[aciklnopst]"))
-					result.add(Format.IMAGE.toString());
-			}
-			break;
-		case 'i':
-			result.add(Format.SOUND_RECORDING.toString());
-			break;
-		case 'j':
-			result.add(Format.MUSIC_RECORDING.toString());
-			break;
-		case 'k':
-			// INDEX-120 Additional criteria for image
-			// IMAGE: 008/33 = a c i k l n o p s t [and I would include values |, blank, and any numerals]
-    			// 008 field, char 33 (count starts at 0)
-			if (cf008 != null && cf008.find("^.{33}[ |0-9aciklnopst]"))
-				result.add(Format.IMAGE.toString());
-			break;
-		case 'm':
-			// look for a in 008 field, char 26 (count starts at 0)
-			if (cf008 != null && cf008.find("^.{26}a"))
-				result.add(Format.DATASET.toString());
-			else
-				result.add(Format.COMPUTER_FILE.toString());
-			break;
-		case 'o': // instructional kit
-			result.add(Format.OTHER.toString());
-			break;
-		case 'r': // 3D object
-			// INDEX-18 implement 3D object resource type
-			result.add(Format.OBJECT.toString());
-			break;
-		case 't':
-			if (leaderChar07 == 'a' || leaderChar07 == 'm')
-				result.add(Format.BOOK.toString());
-			// INDEX-122 Move "Other" collections to Archive/Manuscript
-			// look for Leader/06 = t and Leader/07 = c
-			if (leaderChar07 == 'c')
-				result.add(Format.MANUSCRIPT_ARCHIVE.toString());
-			break;
-		} // end switch
+    // assign formats based on leader chars 06, 07 and chars in 008
+    char leaderChar07 = leaderStr.charAt(7);
+    char leaderChar06 = leaderStr.charAt(6);
+    switch (leaderChar06) {
+    case 'a':
+      if (leaderChar07 == 'a' || leaderChar07 == 'm')
+        result.add(Format.BOOK.toString());
+      // INDEX-75 Move "Other" collections to Archive/Manuscript
+      // look for Leader/06 = a and Leader/07 = c
+      if (leaderChar07 == 'c')
+        result.add(Format.MANUSCRIPT_ARCHIVE.toString());
+      break;
+    case 'b':
+    case 'p':
+      result.add(Format.MANUSCRIPT_ARCHIVE.toString());
+      break;
+    case 'c':
+    case 'd':
+      result.add(Format.MUSIC_SCORE.toString());
+      break;
+    case 'e':
+    case 'f':
+      result.add(Format.MAP.toString());
+      break;
+    case 'g':
+      // INDEX-120 Additional criteria for video and image
+      // VIDEO: 008/33 = f m v [I would also include the values |, blank, and any numerals]
+      // IMAGE: 008/33 = a c i k l n o p s t [some of these should not be used with Leader/06 = g but let's assume the worst]
+      // 008 field, char 33 (count starts at 0)
+      if (cf008 != null)
+      {
+        if (cf008.find("^.{33}[ |0-9fmv]"))
+          result.add(Format.VIDEO.toString());
+        else if (cf008.find("^.{33}[aciklnopst]"))
+          result.add(Format.IMAGE.toString());
+      }
+      break;
+    case 'i':
+      result.add(Format.SOUND_RECORDING.toString());
+      break;
+    case 'j':
+      result.add(Format.MUSIC_RECORDING.toString());
+      break;
+    case 'k':
+      // INDEX-120 Additional criteria for image
+      // IMAGE: 008/33 = a c i k l n o p s t [and I would include values |, blank, and any numerals]
+          // 008 field, char 33 (count starts at 0)
+      if (cf008 != null && cf008.find("^.{33}[ |0-9aciklnopst]"))
+        result.add(Format.IMAGE.toString());
+      break;
+    case 'm':
+      // look for a in 008 field, char 26 (count starts at 0)
+      if (cf008 != null && cf008.find("^.{26}a"))
+        result.add(Format.DATASET.toString());
+      else
+        result.add(Format.COMPUTER_FILE.toString());
+      break;
+    case 'o': // instructional kit
+      result.add(Format.OTHER.toString());
+      break;
+    case 'r': // 3D object
+      // INDEX-18 implement 3D object resource type
+      result.add(Format.OBJECT.toString());
+      break;
+    case 't':
+      if (leaderChar07 == 'a' || leaderChar07 == 'm')
+        result.add(Format.BOOK.toString());
+      // INDEX-122 Move "Other" collections to Archive/Manuscript
+      // look for Leader/06 = t and Leader/07 = c
+      if (leaderChar07 == 'c')
+        result.add(Format.MANUSCRIPT_ARCHIVE.toString());
+      break;
+    } // end switch
 
-		return result;
-	}
-
-
-	/**
-	 * Assign formats based on leader chars 06, 07 and chars in 008
-	 *
-	 * Algorithms for formats are currently in email  message from Vitus Tang to
-	 *  Naomi Dushay, cc Phil Schreur, Margaret Hughes, and Jennifer Vine
-	 *  dated July 23, 2008.
-	 *
-	 * @param leaderStr - the leader field, as a String
-	 * @param cf008 - the 008 field as a ControlField object
-	 * @param Set of Strings containing Format enum values per the given data
-	 * @deprecated
-	 */
-	static Set<String> getFormatsPerLdrAnd008Old(String leaderStr, ControlField cf008)
-	{
-		Set<String> result = new HashSet<String>();
-
-		// Note: MARC21 documentation refers to char numbers that are 0 based,
-		// just like java string indexes, so char "06" is at index 6, and is
-		// the seventh character of the field
-
-		// assign formats based on leader chars 06, 07 and chars in 008
-		char leaderChar07 = leaderStr.charAt(7);
-		char leaderChar06 = leaderStr.charAt(6);
-		switch (leaderChar06) {
-		case 'a':
-			if (leaderChar07 == 'a' || leaderChar07 == 'm')
-				result.add(FormatOld.BOOK.toString());
-			break;
-		case 'b':
-		case 'p':
-			result.add(FormatOld.MANUSCRIPT_ARCHIVE.toString());
-			break;
-		case 'c':
-		case 'd':
-			result.add(FormatOld.MUSIC_SCORE.toString());
-			break;
-		case 'e':
-		case 'f':
-			result.add(FormatOld.MAP_GLOBE.toString());
-			break;
-		case 'g':
-			// look for m or v in 008 field, char 33 (count starts at 0)
-			if (cf008 != null && cf008.find("^.{33}[mv]"))
-				result.add(FormatOld.VIDEO.toString());
-			break;
-		case 'i':
-			result.add(FormatOld.SOUND_RECORDING.toString());
-			break;
-		case 'j':
-			result.add(FormatOld.MUSIC_RECORDING.toString());
-			break;
-		case 'k':
-    		// look for i, k, p, s or t in 008 field, char 33 (count starts at 0)
-			if (cf008 != null && cf008.find("^.{33}[ikpst]"))
-				result.add(FormatOld.IMAGE.toString());
-			break;
-		case 'm':
-			// look for a in 008 field, char 26 (count starts at 0)
-			if (cf008 != null && cf008.find("^.{26}a"))
-				result.add(FormatOld.COMPUTER_FILE.toString());
-			break;
-		case 'o': // instructional kit
-			result.add(FormatOld.OTHER.toString());
-			break;
-		case 'r': // object
-			result.add(FormatOld.OTHER.toString());
-			break;
-		case 't':
-			if (leaderChar07 == 'a' || leaderChar07 == 'm')
-				result.add(FormatOld.BOOK.toString());
-			break;
-		} // end switch
-
-		return result;
-	}
+    return result;
+  }
 
 
-	/**
-	 * return main format for continuing resource
-	 *
-	 * @param leaderStr - the leader field, as a String
-	 * @param cf008c21 - the 21st byte (starting w 0) of 008 field
-	 * @param Set of Strings containing Format enum values per the given data
-	 * @return main format for continuing resource, or null if undetermined
-	 */
-	static String getMainFormatSerial(char leaderChar07, char cf008c21, ControlField f006)
-	{
-		// look for serial format per leader/07 and 008/21
-		if (leaderChar07 == 's'  &&  cf008c21 != '\u0000')
-			return getSerialMainFormatFromChar(cf008c21);
+  /**
+   * Assign formats based on leader chars 06, 07 and chars in 008
+   *
+   * Algorithms for formats are currently in email  message from Vitus Tang to
+   *  Naomi Dushay, cc Phil Schreur, Margaret Hughes, and Jennifer Vine
+   *  dated July 23, 2008.
+   *
+   * @param leaderStr - the leader field, as a String
+   * @param cf008 - the 008 field as a ControlField object
+   * @param Set of Strings containing Format enum values per the given data
+   * @deprecated
+   */
+  static Set<String> getFormatsPerLdrAnd008Old(String leaderStr, ControlField cf008)
+  {
+    Set<String> result = new HashSet<String>();
 
-		return FormatUtils.getSerialMainFormatFrom006(f006);
+    // Note: MARC21 documentation refers to char numbers that are 0 based,
+    // just like java string indexes, so char "06" is at index 6, and is
+    // the seventh character of the field
 
-//		// look for serial format per leader/07 and 008/21
-//		if (leaderChar07 == 's')
-//			result = getSerialMainFormatFromCharLimited(cf008c21);
-//		if (result == null)
-//		{
-//			result = FormatUtils.getSerialMainFormatFrom006(f006);
-//			if ((result == null) && (leaderChar07 == 's'))
-//				// default to journal if 008/21 can be used at all
-//				result = getSerialMainFormatFromChar(cf008c21);
-//		}
-//		return result;
-	}
+    // assign formats based on leader chars 06, 07 and chars in 008
+    char leaderChar07 = leaderStr.charAt(7);
+    char leaderChar06 = leaderStr.charAt(6);
+    switch (leaderChar06) {
+    case 'a':
+      if (leaderChar07 == 'a' || leaderChar07 == 'm')
+        result.add(FormatOld.BOOK.toString());
+      break;
+    case 'b':
+    case 'p':
+      result.add(FormatOld.MANUSCRIPT_ARCHIVE.toString());
+      break;
+    case 'c':
+    case 'd':
+      result.add(FormatOld.MUSIC_SCORE.toString());
+      break;
+    case 'e':
+    case 'f':
+      result.add(FormatOld.MAP_GLOBE.toString());
+      break;
+    case 'g':
+      // look for m or v in 008 field, char 33 (count starts at 0)
+      if (cf008 != null && cf008.find("^.{33}[mv]"))
+        result.add(FormatOld.VIDEO.toString());
+      break;
+    case 'i':
+      result.add(FormatOld.SOUND_RECORDING.toString());
+      break;
+    case 'j':
+      result.add(FormatOld.MUSIC_RECORDING.toString());
+      break;
+    case 'k':
+        // look for i, k, p, s or t in 008 field, char 33 (count starts at 0)
+      if (cf008 != null && cf008.find("^.{33}[ikpst]"))
+        result.add(FormatOld.IMAGE.toString());
+      break;
+    case 'm':
+      // look for a in 008 field, char 26 (count starts at 0)
+      if (cf008 != null && cf008.find("^.{26}a"))
+        result.add(FormatOld.COMPUTER_FILE.toString());
+      break;
+    case 'o': // instructional kit
+      result.add(FormatOld.OTHER.toString());
+      break;
+    case 'r': // object
+      result.add(FormatOld.OTHER.toString());
+      break;
+    case 't':
+      if (leaderChar07 == 'a' || leaderChar07 == 'm')
+        result.add(FormatOld.BOOK.toString());
+      break;
+    } // end switch
 
-	/**
-	 * return format if 006 starts with 's' and 4th char has a desirable
-	 *  value.
-	 *
-	 * @param f006 - 006 as a VariableField object
-	 * @return String containing Format enum value per the given data, or null
-	 * @return main format for continuing resource, or null if undetermined
-	 */
-	static String getSerialMainFormatFrom006(ControlField f006)
-	{
-		if (f006 != null && f006.find("^s")) {
-			char c04 = f006.getData().charAt(4);
-			return getSerialMainFormatFromChar(c04);
-		}
-		return null;
-	}
-
-	/**
-	 * only looks for values of m, n and p
-	 * given a character assumed to be the 21st character (zero-based) from
-	 *  the 008 field or the 4th char from an 006 field, return the format
-	 *  (assuming that there is an indication that the record is for a serial).
-	 *  return null if no format is determined.
-	 */
-	private static String getSerialMainFormatFromCharLimited(char ch) {
-		if (ch != '\u0000')
-			switch (ch) {
-				case 'm': // monographic series
-					return Format.BOOK.toString();
-				case 'n':
-					return Format.NEWSPAPER.toString();
-				case 'p':
-					return Format.JOURNAL_PERIODICAL.toString();
-			}
-		return null;
-	}
-
-
-	/**
-	 * given a character assumed to be the 21st character (zero-based) from
-	 *  the 008 field or the 4th char from an 006 field, return the format
-	 *  (assuming that there is an indication that the record is for a serial).
-	 *  return null if no format is determined.
-	 */
-	private static String getSerialMainFormatFromChar(char ch) {
-		if (ch != '\u0000')
-			switch (ch) {
-				case 'm': // monographic series
-					return Format.BOOK.toString();
-				case 'n':
-					return Format.NEWSPAPER.toString();
-				case 'p':
-				case ' ':  // blank
-				case '|':  // pipe
-				case '#':  // marc documentation uses this to indicate blank
-					return Format.JOURNAL_PERIODICAL.toString();
-			}
-		return getIntegratingMainFormatFromChar(ch);
-//		return null;
-	}
+    return result;
+  }
 
 
-	/**
-	 * given a character assumed to be the 21st character (zero-based) from
-	 *  the 008 field or the 4th char from an 006 field, return the format
-	 *  (assuming that there is an indication that the record is for a serial).
-	 *  return null if no format is determined.
-	 *  INDEX-14 updating database being folded into Database_A_Z
-	 *  INDEX-16 updating website being folded into Journal_Periodical
-	 *  INDEX-15 updating other (default) being folded into Book
-	 */
-	protected static String getIntegratingMainFormatFromChar(char ch) {
-		if (ch != '\u0000')
-			switch (ch) {
-				case 'd':
-					return Format.DATABASE_A_Z.toString();
-				case 'l':
-					return Format.BOOK.toString();
-				case 'w':
-					return Format.JOURNAL_PERIODICAL.toString();
-				default:
-					return Format.BOOK.toString();
-			}
-		return null;
-	}
+  /**
+   * return main format for continuing resource
+   *
+   * @param leaderStr - the leader field, as a String
+   * @param cf008c21 - the 21st byte (starting w 0) of 008 field
+   * @param Set of Strings containing Format enum values per the given data
+   * @return main format for continuing resource, or null if undetermined
+   */
+  static String getMainFormatSerial(char leaderChar07, char cf008c21, ControlField f006)
+  {
+    // look for serial format per leader/07 and 008/21
+    if (leaderChar07 == 's'  &&  cf008c21 != '\u0000')
+      return getSerialMainFormatFromChar(cf008c21);
+
+    return FormatUtils.getSerialMainFormatFrom006(f006);
+
+//    // look for serial format per leader/07 and 008/21
+//    if (leaderChar07 == 's')
+//      result = getSerialMainFormatFromCharLimited(cf008c21);
+//    if (result == null)
+//    {
+//      result = FormatUtils.getSerialMainFormatFrom006(f006);
+//      if ((result == null) && (leaderChar07 == 's'))
+//        // default to journal if 008/21 can be used at all
+//        result = getSerialMainFormatFromChar(cf008c21);
+//    }
+//    return result;
+  }
+
+  /**
+   * return format if 006 starts with 's' and 4th char has a desirable
+   *  value.
+   *
+   * @param f006 - 006 as a VariableField object
+   * @return String containing Format enum value per the given data, or null
+   * @return main format for continuing resource, or null if undetermined
+   */
+  static String getSerialMainFormatFrom006(ControlField f006)
+  {
+    if (f006 != null && f006.find("^s")) {
+      char c04 = f006.getData().charAt(4);
+      return getSerialMainFormatFromChar(c04);
+    }
+    return null;
+  }
+
+  /**
+   * only looks for values of m, n and p
+   * given a character assumed to be the 21st character (zero-based) from
+   *  the 008 field or the 4th char from an 006 field, return the format
+   *  (assuming that there is an indication that the record is for a serial).
+   *  return null if no format is determined.
+   */
+  private static String getSerialMainFormatFromCharLimited(char ch) {
+    if (ch != '\u0000')
+      switch (ch) {
+        case 'm': // monographic series
+          return Format.BOOK.toString();
+        case 'n':
+          return Format.NEWSPAPER.toString();
+        case 'p':
+          return Format.JOURNAL_PERIODICAL.toString();
+      }
+    return null;
+  }
 
 
-	/**
-	 * Assign format based on Serial publications - leader/07 s
-	 *
-	 * Algorithms for formats are currently in email  message from Vitus Tang to
-	 *  Naomi Dushay, cc Phil Schreur, Margaret Hughes, and Jennifer Vine
-	 *  dated July 23, 2008.
-	 *
-	 * @param leaderStr - the leader field, as a String
-	 * @param cf008 - the 008 field as a ControlField object
-	 * @param Set of Strings containing Format enum values per the given data
-	 * @deprecated (used for old format only)
-	 */
-	static String getSerialFormat(char leaderChar07, ControlField cf008, VariableField f006)
-	{
-		String result = null;
-		char c21 = '\u0000';
-		if (cf008 != null)
-			c21 = ((ControlField) cf008).getData().charAt(21);
-
-		// look for serial format per leader/07 and 008/21
-		if (leaderChar07 == 's')
-			result = getSerialFormatFromChar(c21);
-		if (result != null)
-			return result;
-
-		// look for serial publications in 006/00 and 006/04
-		result = FormatUtils.getSerialFormat006(f006);
-		if (result != null)
-			return result;
-
-		// default to journal if leader/07 s and 008/21 is blank
-		if (leaderChar07 == 's' && cf008 != null && c21 == ' ')
-			return FormatOld.JOURNAL_PERIODICAL.toString();
-
-		return null;
-	}
-
-	/**
-	 * Assign format if 006 starts with 's' and 4th char has a desirable value.
-	 *
-	 * @param f006 - 006 as a VariableField object
-	 * @return String containing Format enum value per the given data, or null
-	 * @deprecated (used for old format only)
-	 */
-	static String getSerialFormat006(VariableField f006)
-	{
-		if (f006 != null && f006.find("^s")) {
-			char c04 = ((ControlField) f006).getData().charAt(4);
-			String format = getSerialFormatFromChar(c04);
-			if (format != null)
-				return format;
-			if (c04 == ' ')
-				return FormatOld.JOURNAL_PERIODICAL.toString();
-		}
-		return null;
-	}
+  /**
+   * given a character assumed to be the 21st character (zero-based) from
+   *  the 008 field or the 4th char from an 006 field, return the format
+   *  (assuming that there is an indication that the record is for a serial).
+   *  return null if no format is determined.
+   */
+  private static String getSerialMainFormatFromChar(char ch) {
+    if (ch != '\u0000')
+      switch (ch) {
+        case 'm': // monographic series
+          return Format.BOOK.toString();
+        case 'n':
+          return Format.NEWSPAPER.toString();
+        case 'p':
+        case ' ':  // blank
+        case '|':  // pipe
+        case '#':  // marc documentation uses this to indicate blank
+          return Format.JOURNAL_PERIODICAL.toString();
+      }
+    return getIntegratingMainFormatFromChar(ch);
+//    return null;
+  }
 
 
-	/**
-	 * given a character assumed to be the 21st character (zero-based) from
-	 *  the 008 field or the 4th char from an 006 field, return the format
-	 *  (assuming that there is an indication that the record is for a serial).
-	 *  return null if no format is determined.
-	 * @deprecated (used for old format only)
-	 */
-	private static String getSerialFormatFromChar(char ch) {
-		if (ch != '\u0000')
-			switch (ch) {
-				case 'm': // monographic series
-					return FormatOld.BOOK.toString();
-				case 'n':
-					return FormatOld.NEWSPAPER.toString();
-				case 'p':
-					return FormatOld.JOURNAL_PERIODICAL.toString();
-			}
-		return null;
-	}
-
-	/**
-	 * this is kept for continuity with the original format values
-	 * @param record - marc4j record object
-	 * @return true if there is a 245h that contains the string "microform",
-	 *  false otherwise
-	 * @deprecated
-	 */
-	static boolean isMicroformatOld(Record record) {
-		Set<String> titleH = MarcUtils.getSubfieldDataAsSet(record, "245", "h", " ");
-		if (Utils.setItemContains(titleH, "microform"))
-			return true;
-		else
-			return false;
-	}
-
-	/**
-	 * return true if it is a MARCit record
-	 * @param record - marc4j record object
-	 * @return true if there is a 590a that contains the string "MARCit brief record",
-	 *  false otherwise
-	 */
-	static boolean isMarcit(Record record) {
-		Set<String> f590a = MarcUtils.getSubfieldDataAsSet(record, "590", "a", "");
-		if (Utils.setItemContains(f590a, "MARCit brief record"))
-			return true;
-		else
-			return false;
-	}
-
-	/**
-	 * Assign physical formats based on 007, leader chars and 008 chars
-	 * INDEX-89 - Add video physical formats
-	 * INDEX-167 - Added checks for length of 007 to prevent out of bounds errors
-	 *
-	 * @param cf007List - a list of 007 fields as VariableField objects
-	 * @param accessMethods - set of Strings that can be Online or 'At the Library' or both
-	 * @param Set of Strings containing Physical Format enum values as Strings per the given data
-	 */
-	static Set<String> getPhysicalFormatsPer007(List<VariableField> cf007List, Set<String> accessMethods)
-	{
-		Set<String> result = new HashSet<String>();
-
-		// Note: MARC21 documentation refers to char numbers that are 0 based,
-		// just like java string indexes, so char "6" is at index 6, and is
-		// the seventh character of the field
-
-		for (VariableField vf007 : cf007List)
-		{
-			ControlField cf007 = (ControlField) vf007;
-			String cf007data = cf007.getData();
-			if (cf007data != null && cf007data.length() > 0)
-			{
-				switch (cf007data.charAt(0))
-				{
-					case 'g':
-						if (cf007data.length() > 1 && cf007data.charAt(1) == 's')
-							result.add(FormatPhysical.SLIDE.toString());
-						break;
-					case 'h':
-						if (cf007data.length() > 1)
-						{
-							if ("bcdhj".contains(String.valueOf(cf007data.charAt(1))))
-								result.add(FormatPhysical.MICROFILM.toString());
-							else if ("efg".contains(String.valueOf(cf007data.charAt(1))))
-								result.add(FormatPhysical.MICROFICHE.toString());
-						}
-						break;
-					case 'k':
-						if (cf007data.length() > 1 && cf007data.charAt(1) == 'h')
-							result.add(FormatPhysical.PHOTO.toString());
-						break;
-					case 'm':
-						// INDEX-89 - Add video physical formats
-						// FILM - 007/00 = m
-						result.add(FormatPhysical.FILM.toString());
-						break;
-					case 'r':
-						result.add(FormatPhysical.REMOTE_SENSING_IMAGE.toString());
-						break;
-					case 's':
-						if (cf007data.length() > 1 && accessMethods.contains(Access.AT_LIBRARY.toString()))
-						{
-							if (cf007data.charAt(1) == 'd' && cf007data.length() > 3)
-								switch (cf007data.charAt(3))
-								{
-									case 'b':
-										result.add(FormatPhysical.VINYL.toString());
-										break;
-									case 'd':
-										result.add(FormatPhysical.SHELLAC_78.toString());
-										break;
-									case 'f':
-										result.add(FormatPhysical.CD.toString());
-										break;
-								}
-							else if (cf007data.length() > 6 && cf007data.charAt(6) == 'j')
-								result.add(FormatPhysical.CASSETTE.toString());
-						}
-						break;
-					case 'v':
-						if (cf007data.length() > 4)
-							// INDEX-89 - Add video physical formats
-							switch (cf007data.charAt(4))
-							{
-								case 'a':
-								case 'i':
-								case 'j':
-									// Beta - 007/00 = v, 007/04 = a 
-									// Betacam - 007/00 = v, 007/04 = i 
-									// Betacam SP - 007/00 = v, 007/04 = j
-									result.add(FormatPhysical.BETA.toString());
-									break;
-								case 'b':
-									// VHS - 007/00 = v, 007/04 = b
-									result.add(FormatPhysical.VHS.toString());
-									break;
-								case 'g':
-									// Laser disc - 007/00 - v, 007/04 = g
-									result.add(FormatPhysical.LASER_DISC.toString());
-									break;
-								case 'q':
-									// Hi-8 mm - 007/00 = v, 007/04 = q
-									result.add(FormatPhysical.HI_8.toString());
-									break;
-								case 's':
-									// BLURAY - 007/00 = v, 007/04 = s
-									result.add(FormatPhysical.BLURAY.toString());
-									break;
-								case 'v':
-									// DVD - 007/00 = v, 007/04 = v
-									result.add(FormatPhysical.DVD.toString());
-									break;
-								default:
-									result.add(FormatPhysical.OTHER_VIDEO.toString());
-									break;
-							} // switch cf007_4
-						break;  //case v
-				}
-			}
-		}
-
-		return result;
-	}
-
-	/**
- 	 * INDEX-89 - Add video physical formats
-	 * Assign physical format if 538$a contains the following:
-	 * 
-	 * BLURAY - Bluray, Blu-Ray, or Blu ray
-	 * VHS - VHS
-	 * DVD - DVD
-	 * LASER_DISC - CAV or CLV
-	 * VIDEO_CD - VCD, Video CD, or VideoCD
-	 *
-	 * @param record
-	 * @return String containing Physical Format enum value per the given data, or null
-	 */
-	static Set<String> getPhysicalFormat538(Record record)
-	{
-		Set<String> result = new HashSet<String>();
-
-		Set<String> f538a = MarcUtils.getSubfieldDataAsSet(record, "538", "a", "");
-		if (Utils.setItemContains(f538a, "Bluray") || Utils.setItemContains(f538a, "Blu-ray") || Utils.setItemContains(f538a, "Blu ray"))
-			result.add(FormatPhysical.BLURAY.toString());
-		if (Utils.setItemContains(f538a, "VHS"))
-			result.add(FormatPhysical.VHS.toString());
-		if (Utils.setItemContains(f538a, "DVD"))
-			result.add(FormatPhysical.DVD.toString());
-		if (Utils.setItemContains(f538a, "CAV") || Utils.setItemContains(f538a, "CLV"))
-			result.add(FormatPhysical.LASER_DISC.toString());
-		if (Utils.setItemContains(f538a, "VCD") || Utils.setItemContains(f538a, "Video CD") || Utils.setItemContains(f538a, "VideoCD"))
-			result.add(FormatPhysical.VIDEO_CD.toString());
-		return result;
-	}
-
-	/**
- 	 * INDEX-89 - Add video physical formats
-	 * Assign physical format if 300$b and/or 347$b contain the following:
-	 * 
-	 * MPEG-4 - 300$b = MP4, 347$b = MPEG-4
-	 * VIDEO_CD - 300$b or 347$b = VCD, Video CD, or VideoCD
-	 *
-	 * @param record
-	 * @return String containing Physical Format enum value per MP4, or null
-	 */
-	static  Set<String> getPhysicalFormat3xxb(Record record)
-	{
-		Set<String> result = new HashSet<String>();
-
-		Set<String> f300b = MarcUtils.getSubfieldDataAsSet(record, "300", "b", "");
-		Set<String> f347b = MarcUtils.getSubfieldDataAsSet(record, "347", "b", "");
-		if (Utils.setItemContains(f300b, "MP4") || Utils.setItemContains(f347b, "MPEG-4"))
-			result.add(FormatPhysical.MP4.toString());
-		if (Utils.setItemContains(f300b, "VCD") || Utils.setItemContains(f347b, "VCD") || 
-			Utils.setItemContains(f300b, "Video CD") || Utils.setItemContains(f347b, "Video CD") || 
-			Utils.setItemContains(f300b, "VideoCD") || Utils.setItemContains(f347b, "VideoCD"))
-			result.add(FormatPhysical.VIDEO_CD.toString());
-		return result;
-	}
-
-	/**
- 	 * INDEX-89 - Add video physical formats
-	 * Assign video physical format if call number contains the following:
-	 * Green Library
-	 * ZDVD - DVDS
-	 * ZDVD ..... BLU-RAY That's the ZDVD plus a number plus the text string BLU-RAY, all in the same subfield
-	 * ZVC VHS videocassette
-	 * ZVD laserdiscs
-	 * 
-	 * Art Library
-	 * ARTDVD - DVD (we have no procedure for blu-ray so not sure what that number would be)
-	 * ARTVC - VHS videocassette
-	 * 
-	 * Music Library
-	 * MDVD - DVD (no info on blu-ray practice)
-	 * MVC - VHS videocassette
-	 * MVD - laserdiscs
-	 * 
-	 * Archive of Recorded Sound:
-	 * AVC - videocassettes (not necessarily only VHS)
-	 * ADVD - DVD
-	 * 
-	 * @param record
-	 * @return String containing Physical Format enum value per the given data, or null
-	 */
-	static Set<String> getPhysicalFormat999(Record record)
-	{
-		Set<String> result = new HashSet<String>();
-
-		Set<String> f999a = MarcUtils.getSubfieldDataAsSet(record, "999", "a", "");
-		if (Utils.setItemContains(f999a, "BLU-RAY"))
-			result.add(FormatPhysical.BLURAY.toString());
-		if (Utils.setItemContains(f999a, "ZVC") || Utils.setItemContains(f999a, "ARTVC") || Utils.setItemContains(f999a, "MVC"))
-			result.add(FormatPhysical.VHS.toString());
-		if (Utils.setItemContains(f999a, "ZDVD") || Utils.setItemContains(f999a, "ARTDVD") || Utils.setItemContains(f999a, "MDVD") || Utils.setItemContains(f999a, "ADVD"))
-			result.add(FormatPhysical.DVD.toString());
-		if (Utils.setItemContains(f999a, "AVC"))
-			result.add(FormatPhysical.VIDEOCASSETTE.toString());
-		if (Utils.setItemContains(f999a, "ZVD") || Utils.setItemContains(f999a, "MVD"))
-			result.add(FormatPhysical.LASER_DISC.toString());
-		return result;
-	}
-
-	/**
-	 * use regex to find audio CD descriptions in 300 field
-	 *   values like
-	 *     1 sound disc : digital, stereo ; 4 3/4 in.
-	 *     2 sound discs : digital, mono. ; 12 cm.
-	 *   see also the test in FormatPhysicalTests
-	 * @param str
-	 * @return true if it matches
-	 */
-	public static boolean describesCD(String str)
-	{
-		Pattern cdPattern = Pattern.compile(".*(sound|audio) discs? (\\((ca. )?\\d+.*\\))?\\D+((digital|CD audio)\\D*[,;.])? (c )?(4 3/4|12 c).*", Pattern.CASE_INSENSITIVE);
-		Matcher cdMatcher = cdPattern.matcher(str);
-		Pattern dvdPattern = Pattern.compile(".*DVD.*", Pattern.CASE_INSENSITIVE);
-		Matcher dvdMatcher = dvdPattern.matcher(str);
-		Pattern sacdPattern = Pattern.compile(".*SACD.*", Pattern.CASE_INSENSITIVE);
-		Matcher sacdMatcher = sacdPattern.matcher(str);
-		Pattern blurayPattern = Pattern.compile(".*blu[- ]?ray.*", Pattern.CASE_INSENSITIVE);
-		Matcher blurayMatcher = blurayPattern.matcher(str);
-		if (cdMatcher.matches() && !dvdMatcher.matches() && !sacdMatcher.matches() && !blurayMatcher.matches())
-			return true;
-		else
-			return false;
-	}
-
-	/**
-	 * use regex to find vinyl LP  descriptions in 300 field
-	 *   values like
-	 *     2s. 12in. 33.3rpm.
-	 *     1 sound disc : 33 1/3 rpm, stereo ; 12 in.
-	 *     1 sound disc : analog, 33 1/3 rpm, stereo. ; 12 in.
-	 *   see also the test in FormatPhysicalTests
-	 * @param str
-	 * @return true if it matches
-	 */
-	public static boolean describesVinyl(String str)
-	{
-		Pattern rpmPattern = Pattern.compile(".*33(\\.3| 1/3) ?rpm.*", Pattern.CASE_INSENSITIVE);
-		Matcher rpmMatcher = rpmPattern.matcher(str);
-		Pattern sizePattern = Pattern.compile(".*(10|12) ?in.*", Pattern.CASE_INSENSITIVE);
-		Matcher sizeMatcher = sizePattern.matcher(str);
-		if (rpmMatcher.matches() && sizeMatcher.matches())
-			return true;
-		else
-			return false;
-	}
-
-	/**
-	 * use regex to determine if equipment based upon value in 914
-	 * @param record - marc4j record object
-	 * @return true if there is a 914a that contains the string "EQUIP",
-	 *  false otherwise
-	 */
-	static boolean isEquipment(Record record) {
-		Set<String> equipA = MarcUtils.getSubfieldDataAsSet(record, "914", "a", " ");
-		if (Utils.setItemContains(equipA, "EQUIP"))
-			return true;
-		else
-			return false;
-	}
+  /**
+   * given a character assumed to be the 21st character (zero-based) from
+   *  the 008 field or the 4th char from an 006 field, return the format
+   *  (assuming that there is an indication that the record is for a serial).
+   *  return null if no format is determined.
+   *  INDEX-14 updating database being folded into Database_A_Z
+   *  INDEX-16 updating website being folded into Journal_Periodical
+   *  INDEX-15 updating other (default) being folded into Book
+   */
+  protected static String getIntegratingMainFormatFromChar(char ch) {
+    if (ch != '\u0000')
+      switch (ch) {
+        case 'd':
+          return Format.DATABASE_A_Z.toString();
+        case 'l':
+          return Format.BOOK.toString();
+        case 'w':
+          return Format.JOURNAL_PERIODICAL.toString();
+        default:
+          return Format.BOOK.toString();
+      }
+    return null;
+  }
 
 
-	/**
-	 * use regex to determine if can remove item from "Other" resource type using 245h
-	 * Ignore capitalization variations and punctuation variations (this includes cases where the square brackets are not present,
-	 *  where one square bracket is not present, where there is punctuation inside or outside the brackets, where parentheses are
-	 *  used instead of square brackets, etc.)
-	 * Set resource type to video if 245h contains the following:
-	 * 		[videorecording], [video recording], [videorecordings], [video recordings], [motion picture], [filmstrip], [VCD-DVD], [videodisc], and [videocassette]
-	 * Set resource type to manuscript_archive if 245h contains [manuscript] or [manuscript/digital]
-	 * Set resource type to sound_recording if 245h contains [sound recording]
-	 * Set resource type to image if 245h contains
-	 * 		[art original/digital graphic], [slide], [slides], [chart], [art reproduction], [graphic], [technical drawing],
-	 * 		[flash card], [transparency], [digital graphic], [activity card], [picture], [graphic/digital graphic], [diapositives]
-	 * INDEX-120 remove [print] because of false hits from Lane Medical
-	 * INDEX-121 If 245h contains: kit, then look at first 007/00 for primary format: 
-	 *						a Map --> Map/Globe 
-	 *						c Electronic resource --> Software/Multimedia 
-     *						d Globe --> Map/Globe 
-	 *						g Projected graphic --> Video 
-	 *						k Nonprojected graphic --> Image 
-	 *						m Motion picture --> Video 
-	 *						q Notated music --> Music score 
-	 *						r Remote-sensing image --> Image 
-	 *						s Sound recording --> Sound recording 
-	 *						v Videorecording --> Video 
-	 * @param record - marc4j record object
-	 * @return new resource type or null
-	 */
-	static String getFormatsPer245h(String sf245h, ControlField cf007)
-	{
-		String format = "";
-		String clean245h = Utils.cleanData(sf245h.toString().toLowerCase());
+  /**
+   * Assign format based on Serial publications - leader/07 s
+   *
+   * Algorithms for formats are currently in email  message from Vitus Tang to
+   *  Naomi Dushay, cc Phil Schreur, Margaret Hughes, and Jennifer Vine
+   *  dated July 23, 2008.
+   *
+   * @param leaderStr - the leader field, as a String
+   * @param cf008 - the 008 field as a ControlField object
+   * @param Set of Strings containing Format enum values per the given data
+   * @deprecated (used for old format only)
+   */
+  static String getSerialFormat(char leaderChar07, ControlField cf008, VariableField f006)
+  {
+    String result = null;
+    char c21 = '\u0000';
+    if (cf008 != null)
+      c21 = ((ControlField) cf008).getData().charAt(21);
 
-		if (clean245h.contains("video") || clean245h.contains("motion picture")  || clean245h.contains("filmstrip")  || clean245h.contains("vcd-dvd"))
-				return Format.VIDEO.toString();
-		else if (clean245h.contains("manuscript"))
-				return Format.MANUSCRIPT_ARCHIVE.toString();
-		else if (clean245h.contains("sound recording"))
-				return Format.SOUND_RECORDING.toString();
-		else if (clean245h.contains("graphic") || clean245h.contains("slide") || clean245h.contains("chart") || clean245h.contains("art reproduction")  ||
-					clean245h.contains("technical drawing")  || clean245h.contains("flash card")  || clean245h.contains("transparency") || clean245h.contains("activity card")  ||
-					clean245h.contains("picture")  || clean245h.contains("diapositives"))
-				return Format.IMAGE.toString();
-		else if (clean245h.contains("kit"))
-		{
-			if (cf007 != null)
-			{
-				switch (cf007.getData().charAt(0)) {
-					case 'a':
-					case 'd':
-						format = Format.MAP.toString();
-						break;
-					case 'c':
-						format = Format.COMPUTER_FILE.toString();
-						break;
-					case 'g':
-					case 'm':
-					case 'v':
-						format = Format.VIDEO.toString();
-						break;
-					case 'k':
-					case 'r':
-						format = Format.IMAGE.toString();
-						break;
-					case 'q':
-						format = Format.MUSIC_SCORE.toString();
-						break;
-					case 's':
-						format = Format.SOUND_RECORDING.toString();
-						break;
-					default:
-						format = null;
-						break;
-				} // end switch
-				return format;
-			}
-			else
-				return null;
-		}
-		else
-				return null;
-	}
+    // look for serial format per leader/07 and 008/21
+    if (leaderChar07 == 's')
+      result = getSerialFormatFromChar(c21);
+    if (result != null)
+      return result;
+
+    // look for serial publications in 006/00 and 006/04
+    result = FormatUtils.getSerialFormat006(f006);
+    if (result != null)
+      return result;
+
+    // default to journal if leader/07 s and 008/21 is blank
+    if (leaderChar07 == 's' && cf008 != null && c21 == ' ')
+      return FormatOld.JOURNAL_PERIODICAL.toString();
+
+    return null;
+  }
+
+  /**
+   * Assign format if 006 starts with 's' and 4th char has a desirable value.
+   *
+   * @param f006 - 006 as a VariableField object
+   * @return String containing Format enum value per the given data, or null
+   * @deprecated (used for old format only)
+   */
+  static String getSerialFormat006(VariableField f006)
+  {
+    if (f006 != null && f006.find("^s")) {
+      char c04 = ((ControlField) f006).getData().charAt(4);
+      String format = getSerialFormatFromChar(c04);
+      if (format != null)
+        return format;
+      if (c04 == ' ')
+        return FormatOld.JOURNAL_PERIODICAL.toString();
+    }
+    return null;
+  }
+
+
+  /**
+   * given a character assumed to be the 21st character (zero-based) from
+   *  the 008 field or the 4th char from an 006 field, return the format
+   *  (assuming that there is an indication that the record is for a serial).
+   *  return null if no format is determined.
+   * @deprecated (used for old format only)
+   */
+  private static String getSerialFormatFromChar(char ch) {
+    if (ch != '\u0000')
+      switch (ch) {
+        case 'm': // monographic series
+          return FormatOld.BOOK.toString();
+        case 'n':
+          return FormatOld.NEWSPAPER.toString();
+        case 'p':
+          return FormatOld.JOURNAL_PERIODICAL.toString();
+      }
+    return null;
+  }
+
+  /**
+   * this is kept for continuity with the original format values
+   * @param record - marc4j record object
+   * @return true if there is a 245h that contains the string "microform",
+   *  false otherwise
+   * @deprecated
+   */
+  static boolean isMicroformatOld(Record record) {
+    Set<String> titleH = MarcUtils.getSubfieldDataAsSet(record, "245", "h", " ");
+    if (Utils.setItemContains(titleH, "microform"))
+      return true;
+    else
+      return false;
+  }
+
+  /**
+   * return true if it is a MARCit record
+   * @param record - marc4j record object
+   * @return true if there is a 590a that contains the string "MARCit brief record",
+   *  false otherwise
+   */
+  static boolean isMarcit(Record record) {
+    Set<String> f590a = MarcUtils.getSubfieldDataAsSet(record, "590", "a", "");
+    if (Utils.setItemContains(f590a, "MARCit brief record"))
+      return true;
+    else
+      return false;
+  }
+
+  /**
+   * Assign physical formats based on 007, leader chars and 008 chars
+   * INDEX-89 - Add video physical formats
+   * INDEX-167 - Added checks for length of 007 to prevent out of bounds errors
+   * SW-1531 - Add piano and organ rolls as a media type
+   *          if 007/00 = 's' and 007/01 = 'q'
+   *
+   * @param cf007List - a list of 007 fields as VariableField objects
+   * @param accessMethods - set of Strings that can be Online or 'At the Library' or both
+   * @param Set of Strings containing Physical Format enum values as Strings per the given data
+   */
+  static Set<String> getPhysicalFormatsPer007(List<VariableField> cf007List, Set<String> accessMethods)
+  {
+    Set<String> result = new HashSet<String>();
+
+    // Note: MARC21 documentation refers to char numbers that are 0 based,
+    // just like java string indexes, so char "6" is at index 6, and is
+    // the seventh character of the field
+
+    for (VariableField vf007 : cf007List)
+    {
+      ControlField cf007 = (ControlField) vf007;
+      String cf007data = cf007.getData();
+      if (cf007data != null && cf007data.length() > 0)
+      {
+        switch (cf007data.charAt(0))
+        {
+          case 'g':
+            if (cf007data.length() > 1 && cf007data.charAt(1) == 's')
+              result.add(FormatPhysical.SLIDE.toString());
+            break;
+          case 'h':
+            if (cf007data.length() > 1)
+            {
+              if ("bcdhj".contains(String.valueOf(cf007data.charAt(1))))
+                result.add(FormatPhysical.MICROFILM.toString());
+              else if ("efg".contains(String.valueOf(cf007data.charAt(1))))
+                result.add(FormatPhysical.MICROFICHE.toString());
+            }
+            break;
+          case 'k':
+            if (cf007data.length() > 1 && cf007data.charAt(1) == 'h')
+              result.add(FormatPhysical.PHOTO.toString());
+            break;
+          case 'm':
+            // INDEX-89 - Add video physical formats
+            // FILM - 007/00 = m
+            result.add(FormatPhysical.FILM.toString());
+            break;
+          case 'r':
+            result.add(FormatPhysical.REMOTE_SENSING_IMAGE.toString());
+            break;
+          case 's':
+            if (cf007data.length() > 1 && accessMethods.contains(Access.AT_LIBRARY.toString()))
+            {
+              if (cf007data.charAt(1) == 'd' && cf007data.length() > 3)
+                switch (cf007data.charAt(3))
+                {
+                  case 'b':
+                    result.add(FormatPhysical.VINYL.toString());
+                    break;
+                  case 'd':
+                    result.add(FormatPhysical.SHELLAC_78.toString());
+                    break;
+                  case 'f':
+                    result.add(FormatPhysical.CD.toString());
+                    break;
+                }
+              else if (cf007data.length() > 6 && cf007data.charAt(6) == 'j')
+                result.add(FormatPhysical.CASSETTE.toString());
+              else if (cf007data.charAt(1) == 'q')
+                result.add(FormatPhysical.PIANO_ORGAN_ROLL.toString());
+            }
+            break;
+          case 'v':
+            if (cf007data.length() > 4)
+              // INDEX-89 - Add video physical formats
+              switch (cf007data.charAt(4))
+              {
+                case 'a':
+                case 'i':
+                case 'j':
+                  // Beta - 007/00 = v, 007/04 = a
+                  // Betacam - 007/00 = v, 007/04 = i
+                  // Betacam SP - 007/00 = v, 007/04 = j
+                  result.add(FormatPhysical.BETA.toString());
+                  break;
+                case 'b':
+                  // VHS - 007/00 = v, 007/04 = b
+                  result.add(FormatPhysical.VHS.toString());
+                  break;
+                case 'g':
+                  // Laser disc - 007/00 - v, 007/04 = g
+                  result.add(FormatPhysical.LASER_DISC.toString());
+                  break;
+                case 'q':
+                  // Hi-8 mm - 007/00 = v, 007/04 = q
+                  result.add(FormatPhysical.HI_8.toString());
+                  break;
+                case 's':
+                  // BLURAY - 007/00 = v, 007/04 = s
+                  result.add(FormatPhysical.BLURAY.toString());
+                  break;
+                case 'v':
+                  // DVD - 007/00 = v, 007/04 = v
+                  result.add(FormatPhysical.DVD.toString());
+                  break;
+                default:
+                  result.add(FormatPhysical.OTHER_VIDEO.toString());
+                  break;
+              } // switch cf007_4
+            break;  //case v
+        }
+      }
+
+    }
+
+    return result;
+  }
+
+  /**
+   * INDEX-89 - Add video physical formats
+   * Assign physical format if 538$a contains the following:
+   *
+   * BLURAY - Bluray, Blu-Ray, or Blu ray
+   * VHS - VHS
+   * DVD - DVD
+   * LASER_DISC - CAV or CLV
+   * VIDEO_CD - VCD, Video CD, or VideoCD
+   *
+   * @param record
+   * @return String containing Physical Format enum value per the given data, or null
+   */
+  static Set<String> getPhysicalFormat538(Record record)
+  {
+    Set<String> result = new HashSet<String>();
+
+    Set<String> f538a = MarcUtils.getSubfieldDataAsSet(record, "538", "a", "");
+    if (Utils.setItemContains(f538a, "Bluray") || Utils.setItemContains(f538a, "Blu-ray") || Utils.setItemContains(f538a, "Blu ray"))
+      result.add(FormatPhysical.BLURAY.toString());
+    if (Utils.setItemContains(f538a, "VHS"))
+      result.add(FormatPhysical.VHS.toString());
+    if (Utils.setItemContains(f538a, "DVD"))
+      result.add(FormatPhysical.DVD.toString());
+    if (Utils.setItemContains(f538a, "CAV") || Utils.setItemContains(f538a, "CLV"))
+      result.add(FormatPhysical.LASER_DISC.toString());
+    if (Utils.setItemContains(f538a, "VCD") || Utils.setItemContains(f538a, "Video CD") || Utils.setItemContains(f538a, "VideoCD"))
+      result.add(FormatPhysical.VIDEO_CD.toString());
+    return result;
+  }
+
+  /**
+    * INDEX-89 - Add video physical formats
+   * Assign physical format if 300$b and/or 347$b contain the following:
+   *
+   * MPEG-4 - 300$b = MP4, 347$b = MPEG-4
+   * VIDEO_CD - 300$b or 347$b = VCD, Video CD, or VideoCD
+   *
+   * SW-1531 - Add piano and organ rolls as a media type
+   * Assign physical format if 338$a or 300$a contains "audio roll"
+
+   * @param record
+   * @return String containing Physical Format enum value, or null
+   */
+  static  Set<String> getPhysicalFormat3xxb(Record record)
+  {
+    Set<String> result = new HashSet<String>();
+
+    Set<String> f300b = MarcUtils.getSubfieldDataAsSet(record, "300", "b", "");
+    Set<String> f347b = MarcUtils.getSubfieldDataAsSet(record, "347", "b", "");
+    if (Utils.setItemContains(f300b, "MP4") || Utils.setItemContains(f347b, "MPEG-4"))
+      result.add(FormatPhysical.MP4.toString());
+    if (Utils.setItemContains(f300b, "VCD") || Utils.setItemContains(f347b, "VCD") ||
+      Utils.setItemContains(f300b, "Video CD") || Utils.setItemContains(f347b, "Video CD") ||
+      Utils.setItemContains(f300b, "VideoCD") || Utils.setItemContains(f347b, "VideoCD"))
+      result.add(FormatPhysical.VIDEO_CD.toString());
+
+    Set<String> f338a = MarcUtils.getSubfieldDataAsSet(record, "338", "a", "");
+    Set<String> f300a = MarcUtils.getSubfieldDataAsSet(record, "300", "a", "");
+    if (Utils.setItemContains(f338a, "audio roll") ||
+        Utils.setItemContains(f300a, "audio roll"))
+      result.add(FormatPhysical.PIANO_ORGAN_ROLL.toString());
+    return result;
+  }
+
+  /**
+    * INDEX-89 - Add video physical formats
+   * Assign video physical format if call number contains the following:
+   * Green Library
+   * ZDVD - DVDS
+   * ZDVD ..... BLU-RAY That's the ZDVD plus a number plus the text string BLU-RAY, all in the same subfield
+   * ZVC VHS videocassette
+   * ZVD laserdiscs
+   *
+   * Art Library
+   * ARTDVD - DVD (we have no procedure for blu-ray so not sure what that number would be)
+   * ARTVC - VHS videocassette
+   *
+   * Music Library
+   * MDVD - DVD (no info on blu-ray practice)
+   * MVC - VHS videocassette
+   * MVD - laserdiscs
+   *
+   * Archive of Recorded Sound:
+   * AVC - videocassettes (not necessarily only VHS)
+   * ADVD - DVD
+   *
+   * @param record
+   * @return String containing Physical Format enum value per the given data, or null
+   */
+  static Set<String> getPhysicalFormat999(Record record)
+  {
+    Set<String> result = new HashSet<String>();
+
+    Set<String> f999a = MarcUtils.getSubfieldDataAsSet(record, "999", "a", "");
+    if (Utils.setItemContains(f999a, "BLU-RAY"))
+      result.add(FormatPhysical.BLURAY.toString());
+    if (Utils.setItemContains(f999a, "ZVC") || Utils.setItemContains(f999a, "ARTVC") || Utils.setItemContains(f999a, "MVC"))
+      result.add(FormatPhysical.VHS.toString());
+    if (Utils.setItemContains(f999a, "ZDVD") || Utils.setItemContains(f999a, "ARTDVD") || Utils.setItemContains(f999a, "MDVD") || Utils.setItemContains(f999a, "ADVD"))
+      result.add(FormatPhysical.DVD.toString());
+    if (Utils.setItemContains(f999a, "AVC"))
+      result.add(FormatPhysical.VIDEOCASSETTE.toString());
+    if (Utils.setItemContains(f999a, "ZVD") || Utils.setItemContains(f999a, "MVD"))
+      result.add(FormatPhysical.LASER_DISC.toString());
+    return result;
+  }
+
+  /**
+   * use regex to find audio CD descriptions in 300 field
+   *   values like
+   *     1 sound disc : digital, stereo ; 4 3/4 in.
+   *     2 sound discs : digital, mono. ; 12 cm.
+   *   see also the test in FormatPhysicalTests
+   * @param str
+   * @return true if it matches
+   */
+  public static boolean describesCD(String str)
+  {
+    Pattern cdPattern = Pattern.compile(".*(sound|audio) discs? (\\((ca. )?\\d+.*\\))?\\D+((digital|CD audio)\\D*[,;.])? (c )?(4 3/4|12 c).*", Pattern.CASE_INSENSITIVE);
+    Matcher cdMatcher = cdPattern.matcher(str);
+    Pattern dvdPattern = Pattern.compile(".*DVD.*", Pattern.CASE_INSENSITIVE);
+    Matcher dvdMatcher = dvdPattern.matcher(str);
+    Pattern sacdPattern = Pattern.compile(".*SACD.*", Pattern.CASE_INSENSITIVE);
+    Matcher sacdMatcher = sacdPattern.matcher(str);
+    Pattern blurayPattern = Pattern.compile(".*blu[- ]?ray.*", Pattern.CASE_INSENSITIVE);
+    Matcher blurayMatcher = blurayPattern.matcher(str);
+    if (cdMatcher.matches() && !dvdMatcher.matches() && !sacdMatcher.matches() && !blurayMatcher.matches())
+      return true;
+    else
+      return false;
+  }
+
+  /**
+   * use regex to find vinyl LP  descriptions in 300 field
+   *   values like
+   *     2s. 12in. 33.3rpm.
+   *     1 sound disc : 33 1/3 rpm, stereo ; 12 in.
+   *     1 sound disc : analog, 33 1/3 rpm, stereo. ; 12 in.
+   *   see also the test in FormatPhysicalTests
+   * @param str
+   * @return true if it matches
+   */
+  public static boolean describesVinyl(String str)
+  {
+    Pattern rpmPattern = Pattern.compile(".*33(\\.3| 1/3) ?rpm.*", Pattern.CASE_INSENSITIVE);
+    Matcher rpmMatcher = rpmPattern.matcher(str);
+    Pattern sizePattern = Pattern.compile(".*(10|12) ?in.*", Pattern.CASE_INSENSITIVE);
+    Matcher sizeMatcher = sizePattern.matcher(str);
+    if (rpmMatcher.matches() && sizeMatcher.matches())
+      return true;
+    else
+      return false;
+  }
+
+  /**
+   * use regex to determine if equipment based upon value in 914
+   * @param record - marc4j record object
+   * @return true if there is a 914a that contains the string "EQUIP",
+   *  false otherwise
+   */
+  static boolean isEquipment(Record record) {
+    Set<String> equipA = MarcUtils.getSubfieldDataAsSet(record, "914", "a", " ");
+    if (Utils.setItemContains(equipA, "EQUIP"))
+      return true;
+    else
+      return false;
+  }
+
+
+  /**
+   * use regex to determine if can remove item from "Other" resource type using 245h
+   * Ignore capitalization variations and punctuation variations (this includes cases where the square brackets are not present,
+   *  where one square bracket is not present, where there is punctuation inside or outside the brackets, where parentheses are
+   *  used instead of square brackets, etc.)
+   * Set resource type to video if 245h contains the following:
+   *     [videorecording], [video recording], [videorecordings], [video recordings], [motion picture], [filmstrip], [VCD-DVD], [videodisc], and [videocassette]
+   * Set resource type to manuscript_archive if 245h contains [manuscript] or [manuscript/digital]
+   * Set resource type to sound_recording if 245h contains [sound recording]
+   * Set resource type to image if 245h contains
+   *     [art original/digital graphic], [slide], [slides], [chart], [art reproduction], [graphic], [technical drawing],
+   *     [flash card], [transparency], [digital graphic], [activity card], [picture], [graphic/digital graphic], [diapositives]
+   * INDEX-120 remove [print] because of false hits from Lane Medical
+   * INDEX-121 If 245h contains: kit, then look at first 007/00 for primary format:
+   *            a Map --> Map/Globe
+   *            c Electronic resource --> Software/Multimedia
+     *            d Globe --> Map/Globe
+   *            g Projected graphic --> Video
+   *            k Nonprojected graphic --> Image
+   *            m Motion picture --> Video
+   *            q Notated music --> Music score
+   *            r Remote-sensing image --> Image
+   *            s Sound recording --> Sound recording
+   *            v Videorecording --> Video
+   * @param record - marc4j record object
+   * @return new resource type or null
+   */
+  static String getFormatsPer245h(String sf245h, ControlField cf007)
+  {
+    String format = "";
+    String clean245h = Utils.cleanData(sf245h.toString().toLowerCase());
+
+    if (clean245h.contains("video") || clean245h.contains("motion picture")  || clean245h.contains("filmstrip")  || clean245h.contains("vcd-dvd"))
+        return Format.VIDEO.toString();
+    else if (clean245h.contains("manuscript"))
+        return Format.MANUSCRIPT_ARCHIVE.toString();
+    else if (clean245h.contains("sound recording"))
+        return Format.SOUND_RECORDING.toString();
+    else if (clean245h.contains("graphic") || clean245h.contains("slide") || clean245h.contains("chart") || clean245h.contains("art reproduction")  ||
+          clean245h.contains("technical drawing")  || clean245h.contains("flash card")  || clean245h.contains("transparency") || clean245h.contains("activity card")  ||
+          clean245h.contains("picture")  || clean245h.contains("diapositives"))
+        return Format.IMAGE.toString();
+    else if (clean245h.contains("kit"))
+    {
+      if (cf007 != null)
+      {
+        switch (cf007.getData().charAt(0)) {
+          case 'a':
+          case 'd':
+            format = Format.MAP.toString();
+            break;
+          case 'c':
+            format = Format.COMPUTER_FILE.toString();
+            break;
+          case 'g':
+          case 'm':
+          case 'v':
+            format = Format.VIDEO.toString();
+            break;
+          case 'k':
+          case 'r':
+            format = Format.IMAGE.toString();
+            break;
+          case 'q':
+            format = Format.MUSIC_SCORE.toString();
+            break;
+          case 's':
+            format = Format.SOUND_RECORDING.toString();
+            break;
+          default:
+            format = null;
+            break;
+        } // end switch
+        return format;
+      }
+      else
+        return null;
+    }
+    else
+        return null;
+  }
 
 }

--- a/stanford-sw/src/edu/stanford/enumValues/FormatPhysical.java
+++ b/stanford-sw/src/edu/stanford/enumValues/FormatPhysical.java
@@ -6,136 +6,139 @@ package edu.stanford.enumValues;
  */
 public enum FormatPhysical
 {
-	// recordings
-	CD,
-	VINYL,
-	VINYL_45,
-	SHELLAC_78,
-	CYLINDER,
-	INSTANTANEOUS_DISC,
-	CASSETTE,
-	CARTRIDGE_8_TRACK,
-	DAT,
-	REEL_TO_REEL,
-	OTHER_RECORDING,
+  // recordings
+  CD,
+  VINYL,
+  VINYL_45,
+  SHELLAC_78,
+  CYLINDER,
+  INSTANTANEOUS_DISC,
+  CASSETTE,
+  CARTRIDGE_8_TRACK,
+  DAT,
+  REEL_TO_REEL,
+  PIANO_ORGAN_ROLL,
+  OTHER_RECORDING,
 
-	// images
-	SLIDE,
-	PHOTO,
-	REMOTE_SENSING_IMAGE,
-	OTHER_IMAGE,
+  // images
+  SLIDE,
+  PHOTO,
+  REMOTE_SENSING_IMAGE,
+  OTHER_IMAGE,
 
-	// videos
-	FILM,
-	DVD,
-	BLURAY,
-	VHS,
-	BETA,
-	BETA_SP,
-	MP4, 
-	HI_8,
-	LASER_DISC,
-	VIDEO_CD,
-	VIDEOCASSETTE,
-	OTHER_VIDEO,
+  // videos
+  FILM,
+  DVD,
+  BLURAY,
+  VHS,
+  BETA,
+  BETA_SP,
+  MP4,
+  HI_8,
+  LASER_DISC,
+  VIDEO_CD,
+  VIDEOCASSETTE,
+  OTHER_VIDEO,
 
-	// maps
-	ATLAS,
-	GLOBE,
-	OTHER_MAPS,
+  // maps
+  ATLAS,
+  GLOBE,
+  OTHER_MAPS,
 
-	// microformats
-	MICROFILM,
-	MICROFICHE,
+  // microformats
+  MICROFILM,
+  MICROFICHE,
 
-	OTHER;
+  OTHER;
 
 
-	/**
-	 * need to override for text of multiple words
-	 * INDEX-134 Change Audio cassette to Audiocassette 
-	 */
-	@Override
-	public String toString() {
-		switch (this) {
-			// recordings
-			case CD:
-				return "CD";
-			case VINYL:
-				return "Vinyl disc";
-			case VINYL_45:
-				return "45 rpm disc";
-			case SHELLAC_78:
-				return "78 rpm (shellac)";
-			case CYLINDER:
-				return "Cylinder (wax)";
-			case INSTANTANEOUS_DISC:
-				return "Instantaneous disc";
-			case CASSETTE:
-				return "Audiocassette";
-			case CARTRIDGE_8_TRACK:
-				return "8-track cartridge";
-			case DAT:
-				return "DAT";
-			case REEL_TO_REEL:
-				return "Reel-to-reel tape";
-			case OTHER_RECORDING:
-				return "Other recording";
+  /**
+   * need to override for text of multiple words
+   * INDEX-134 Change Audio cassette to Audiocassette
+   */
+  @Override
+  public String toString() {
+    switch (this) {
+      // recordings
+      case CD:
+        return "CD";
+      case VINYL:
+        return "Vinyl disc";
+      case VINYL_45:
+        return "45 rpm disc";
+      case SHELLAC_78:
+        return "78 rpm (shellac)";
+      case CYLINDER:
+        return "Cylinder (wax)";
+      case INSTANTANEOUS_DISC:
+        return "Instantaneous disc";
+      case CASSETTE:
+        return "Audiocassette";
+      case CARTRIDGE_8_TRACK:
+        return "8-track cartridge";
+      case DAT:
+        return "DAT";
+      case REEL_TO_REEL:
+        return "Reel-to-reel tape";
+      case PIANO_ORGAN_ROLL:
+        return "Piano/organ roll";
+      case OTHER_RECORDING:
+        return "Other recording";
 
-			// images
-			case SLIDE:
-				return "Slide";
-			case PHOTO:
-				return "Photo";
-			case REMOTE_SENSING_IMAGE:
-				return "Remote-sensing image";
-			case OTHER_IMAGE:
-				return "Other image";
+      // images
+      case SLIDE:
+        return "Slide";
+      case PHOTO:
+        return "Photo";
+      case REMOTE_SENSING_IMAGE:
+        return "Remote-sensing image";
+      case OTHER_IMAGE:
+        return "Other image";
 
-			// videos
-			case FILM:
-				return "Film";
-			case DVD:
-				return "DVD";
-			case BLURAY:
-				return "Blu-ray";
-			case VHS:
-				return "Videocassette (VHS)";
-			case BETA:
-				return "Videocassette (Beta)";
-			case MP4:
-				return "MPEG-4";
-			case HI_8:
-				return "Hi-8 mm";  // INDEX-155 - removed ending period
-			case LASER_DISC:
-				return "Laser disc";
-			case VIDEO_CD:
-				return "Video CD";
-			case OTHER_VIDEO:
-				return "Other video";
+      // videos
+      case FILM:
+        return "Film";
+      case DVD:
+        return "DVD";
+      case BLURAY:
+        return "Blu-ray";
+      case VHS:
+        return "Videocassette (VHS)";
+      case BETA:
+        return "Videocassette (Beta)";
+      case MP4:
+        return "MPEG-4";
+      case HI_8:
+        return "Hi-8 mm";  // INDEX-155 - removed ending period
+      case LASER_DISC:
+        return "Laser disc";
+      case VIDEO_CD:
+        return "Video CD";
+      case OTHER_VIDEO:
+        return "Other video";
 
-			// maps
-			case ATLAS:
-				return "Atlas";
-			case GLOBE:
-				return "Globe";
-			case OTHER_MAPS:
-				return "Other maps";
+      // maps
+      case ATLAS:
+        return "Atlas";
+      case GLOBE:
+        return "Globe";
+      case OTHER_MAPS:
+        return "Other maps";
 
-			// microformats
-			case MICROFILM:
-				return "Microfilm";
-			case MICROFICHE:
-				return "Microfiche";
+      // microformats
+      case MICROFILM:
+        return "Microfilm";
+      case MICROFICHE:
+        return "Microfiche";
 
-			case OTHER:
-				return "Other";
-			default:
-				String lc = super.toString().toLowerCase();
-				String firstchar = lc.substring(0, 1).toUpperCase();
-				return lc.replaceFirst(".{1}", firstchar);
-		}
+      case OTHER:
+        return "Other";
+      default:
+        String lc = super.toString().toLowerCase();
+        String firstchar = lc.substring(0, 1).toUpperCase();
+        return lc.replaceFirst(".{1}", firstchar);
+    }
 
-	}
+  }
 
 }

--- a/stanford-sw/test/src/edu/stanford/FormatPhysicalTests.java
+++ b/stanford-sw/test/src/edu/stanford/FormatPhysicalTests.java
@@ -13,1193 +13,1244 @@ import edu.stanford.enumValues.FormatPhysical;
  */
 public class FormatPhysicalTests extends AbstractStanfordTest
 {
-	private final static String formatFldName = "format_main_ssim";
-	private final static String musicRecFormatVal = Format.MUSIC_RECORDING.toString();
-	private final static String physFormatFldName = "format_physical_ssim";
-	private final MarcFactory factory = MarcFactory.newInstance();
-	private ControlField cf007 = factory.newControlField("007");
-	private DataField df999atLibrary = factory.newDataField("999", ' ', ' ');
-	private DataField df999online = factory.newDataField("999", ' ', ' ');
-	{
-		df999online.addSubfield(factory.newSubfield('a', "INTERNET RESOURCE"));
-		df999online.addSubfield(factory.newSubfield('w', "ASIS"));
-		df999online.addSubfield(factory.newSubfield('i', "2475606-5001"));
-		df999online.addSubfield(factory.newSubfield('l', "INTERNET"));
-		df999online.addSubfield(factory.newSubfield('m', "SUL"));
+  private final static String formatFldName = "format_main_ssim";
+  private final static String musicRecFormatVal = Format.MUSIC_RECORDING.toString();
+  private final static String physFormatFldName = "format_physical_ssim";
+  private final MarcFactory factory = MarcFactory.newInstance();
+  private ControlField cf007 = factory.newControlField("007");
+  private DataField df999atLibrary = factory.newDataField("999", ' ', ' ');
+  private DataField df999online = factory.newDataField("999", ' ', ' ');
+  {
+    df999online.addSubfield(factory.newSubfield('a', "INTERNET RESOURCE"));
+    df999online.addSubfield(factory.newSubfield('w', "ASIS"));
+    df999online.addSubfield(factory.newSubfield('i', "2475606-5001"));
+    df999online.addSubfield(factory.newSubfield('l', "INTERNET"));
+    df999online.addSubfield(factory.newSubfield('m', "SUL"));
 
-		df999atLibrary.addSubfield(factory.newSubfield('a', "F152 .A28"));
-		df999atLibrary.addSubfield(factory.newSubfield('w', "LC"));
-		df999atLibrary.addSubfield(factory.newSubfield('i', "36105018746623"));
-		df999atLibrary.addSubfield(factory.newSubfield('l', "HAS-DIGIT"));
-		df999atLibrary.addSubfield(factory.newSubfield('m', "GREEN"));
-	}
+    df999atLibrary.addSubfield(factory.newSubfield('a', "F152 .A28"));
+    df999atLibrary.addSubfield(factory.newSubfield('w', "LC"));
+    df999atLibrary.addSubfield(factory.newSubfield('i', "36105018746623"));
+    df999atLibrary.addSubfield(factory.newSubfield('l', "HAS-DIGIT"));
+    df999atLibrary.addSubfield(factory.newSubfield('m', "GREEN"));
+  }
 
 @Before
-	public final void setup()
-	{
-		mappingTestInit();
-	}
+  public final void setup()
+  {
+    mappingTestInit();
+  }
 
 // images
 //OTHER_IMAGE,
 
-	/**
-	 * Need to make sure that the 007 is long enough to be able to determine the format physical value
-	 * INDEX-167 - Added checks for length of 007 to prevent out of bounds errors
-	 */
+  /**
+   * Need to make sure that the 007 is long enough to be able to determine the format physical value
+   * INDEX-167 - Added checks for length of 007 to prevent out of bounds errors
+   */
 @Test
-	public void test007Length()
-	{
-		Leader ldr = factory.newLeader("01103cem a22002777a 4500");
-		Record record = factory.newRecord();
-		record.setLeader(ldr);
+  public void test007Length()
+  {
+    Leader ldr = factory.newLeader("01103cem a22002777a 4500");
+    Record record = factory.newRecord();
+    record.setLeader(ldr);
 
-		// 007/00 = m (Film) or r (Remote Sensing Image) require no more characters from the 007
-		cf007.setData("m");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.FILM.toString());
+    // 007/00 = m (Film) or r (Remote Sensing Image) require no more characters from the 007
+    cf007.setData("m");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.FILM.toString());
 
-		// 007/00 = g, h, or k must have an 007/01 = s (Slide), bcdhj (Microflim), efg (Michrofiche), or h (Photo)
-		// 007/00 = g and length = 1, so no value for format_physical_ssim
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("g");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
+    // 007/00 = g, h, or k must have an 007/01 = s (Slide), bcdhj (Microflim), efg (Michrofiche), or h (Photo)
+    // 007/00 = g and length = 1, so no value for format_physical_ssim
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("g");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
 
-		// 007/00 = h, 007/01 = b and length = 2, so has one value for format_physical_ssim - microfilm
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("hb");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.MICROFILM.toString());
+    // 007/00 = h, 007/01 = b and length = 2, so has one value for format_physical_ssim - microfilm
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("hb");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.MICROFILM.toString());
 
-		// 007/00 = s, requires access.AT_LIBRARY and either an 007/01 = d and 007/03 - b (Vinyl), d (Shellac 78), or f (CD) or an 007/06 = j (Cassette)
-		// 007/00 = s, access = At Library, 007/01 = d but length = 2, so no value for format_physical_ssim
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("sd");
-		record.addVariableField(cf007);
-		record.addVariableField(df999atLibrary);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
+    // 007/00 = s, requires access.AT_LIBRARY and either an 007/01 = d and 007/03 - b (Vinyl), d (Shellac 78), or f (CD) or an 007/06 = j (Cassette)
+    // 007/00 = s, access = At Library, 007/01 = d but length = 2, so no value for format_physical_ssim
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("sd");
+    record.addVariableField(cf007);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
 
-		// 007/00 = s, access = At Library, 007/01 = d, 007/03 = f, so has value for format_physical_ssim - CD
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("sd f");
-		record.addVariableField(cf007);
-		record.addVariableField(df999atLibrary);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.CD.toString());
+    // 007/00 = s, access = At Library, 007/01 = d, 007/03 = f, so has value for format_physical_ssim - CD
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("sd f");
+    record.addVariableField(cf007);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.CD.toString());
 
-		// 007/00 = s, access = At Library, 007/06 = j, so has value for format_physical_ssim - Cassette
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("s     j");
-		record.addVariableField(cf007);
-		record.addVariableField(df999atLibrary);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.CASSETTE.toString());
+    // 007/00 = s, access = At Library, 007/06 = j, so has value for format_physical_ssim - Cassette
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("s     j");
+    record.addVariableField(cf007);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.CASSETTE.toString());
 
-		// 007/00 = s, access = At Library, 007/01 = d, 007/03 = ' ', so no value for format_physical_ssim
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("sd    j");
-		record.addVariableField(cf007);
-		record.addVariableField(df999atLibrary);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
+    // 007/00 = s, access = At Library, 007/01 = d, 007/03 = ' ', so no value for format_physical_ssim
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("sd    j");
+    record.addVariableField(cf007);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
 
-		// 007/00 = s, 007/01 = d, 007/03 = f but  access != At Library, so no value for format_physical_ssim
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("sd f");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
+    // 007/00 = s, 007/01 = d, 007/03 = f but  access != At Library, so no value for format_physical_ssim
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("sd f");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
 
-		// 007/00 = v requires 007/04 = aij (Beta), b (VHS), g (Laser Disc), q Hi-8 mm), s (Blu-Ray), v (DVD) or nothing (Other video)
-		// 007/00 = v but length = 1, so no value for format_physical_ssim
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("v");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
+    // 007/00 = v requires 007/04 = aij (Beta), b (VHS), g (Laser Disc), q Hi-8 mm), s (Blu-Ray), v (DVD) or nothing (Other video)
+    // 007/00 = v but length = 1, so no value for format_physical_ssim
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("v");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
 
-		// 007/00 = v but length = 3, so no value for format_physical_ssim
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("v  ");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
+    // 007/00 = v but length = 3, so no value for format_physical_ssim
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("v  ");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
 
-		// 007/00 = v and 007/04 = ' ', so has value for format_physical_ssim - Other video
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("v    ");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.OTHER_VIDEO.toString());
+    // 007/00 = v and 007/04 = ' ', so has value for format_physical_ssim - Other video
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("v    ");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.OTHER_VIDEO.toString());
 
-		// 007/00 = v and 007/04 = g, so has value for format_physical_ssim - Laser disc
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("v   g");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.LASER_DISC.toString());
+    // 007/00 = v and 007/04 = g, so has value for format_physical_ssim - Laser disc
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("v   g");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.LASER_DISC.toString());
 
-		// 007 is an empty string
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
+    // 007 is an empty string
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
 
-		// No 007 but still should have one format_physical_ssim based upon 538
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		DataField df538 = factory.newDataField("538", ' ', ' ');
-		df538.addSubfield(factory.newSubfield('a', "DVD"));
-		record.addVariableField(df538);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.DVD.toString());
+    // No 007 but still should have one format_physical_ssim based upon 538
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    DataField df538 = factory.newDataField("538", ' ', ' ');
+    df538.addSubfield(factory.newSubfield('a', "DVD"));
+    record.addVariableField(df538);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.DVD.toString());
 
-	}
+  }
 
-	/**
-	 *  Spec (per Vitus 2013-11, email to gryph-search with Excel spreadsheet attachment):
-	 *   (007/00 = g AND  007/01 = s)  OR  300a contains "slide"
-	 */
+  /**
+   *  Spec (per Vitus 2013-11, email to gryph-search with Excel spreadsheet attachment):
+   *   (007/00 = g AND  007/01 = s)  OR  300a contains "slide"
+   */
 @Test
-	public void testSlide()
-	{
-		String expVal = FormatPhysical.SLIDE.toString();
-		Record record = factory.newRecord();
-		record.setLeader(factory.newLeader("01291cgm a2200289 a 4500"));
+  public void testSlide()
+  {
+    String expVal = FormatPhysical.SLIDE.toString();
+    Record record = factory.newRecord();
+    record.setLeader(factory.newLeader("01291cgm a2200289 a 4500"));
 
-		// 007/01 is not correct for Slide
-		cf007.setData("gd|cu  jc");
-		record.addVariableField(cf007);
-//		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-//		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.OTHER.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 0);
-		solrFldMapTest.assertNoSolrFld(record, physFormatFldName);
+    // 007/01 is not correct for Slide
+    cf007.setData("gd|cu  jc");
+    record.addVariableField(cf007);
+//    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+//    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.OTHER.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 0);
+    solrFldMapTest.assertNoSolrFld(record, physFormatFldName);
 
-		// 007/00 is g, 007/01 is s
-		record.removeVariableField(cf007);
-		cf007.setData("gs|cu  jc");
-		record.addVariableField(cf007);
-//		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-//		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.OTHER.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 0);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // 007/00 is g, 007/01 is s
+    record.removeVariableField(cf007);
+    cf007.setData("gs|cu  jc");
+    record.addVariableField(cf007);
+//    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+//    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.OTHER.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 0);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
 
-		// 300a contains slide
-		record = factory.newRecord();
-		record.setLeader(factory.newLeader("02709ckd a2200505Mi 4500"));
-		DataField df300 = factory.newDataField("300", ' ', ' ');
-		df300.addSubfield(factory.newSubfield('a', "1 pair of stereoscopic slides +"));
-		df300.addSubfield(factory.newSubfield('e', "legend and diagram."));
-		record.addVariableField(df300);
-//		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-//		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.OTHER.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 0);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
-	}
+    // 300a contains slide
+    record = factory.newRecord();
+    record.setLeader(factory.newLeader("02709ckd a2200505Mi 4500"));
+    DataField df300 = factory.newDataField("300", ' ', ' ');
+    df300.addSubfield(factory.newSubfield('a', "1 pair of stereoscopic slides +"));
+    df300.addSubfield(factory.newSubfield('e', "legend and diagram."));
+    record.addVariableField(df300);
+//    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+//    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.OTHER.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 0);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+  }
 
-	/**
-	 *  Spec (per Vitus 2013-11, email to gryph-search with Excel spreadsheet attachment):
-	 *   (007/00 = k AND  007/01 = h)  OR  300a contains "photograph"
-	 */
+  /**
+   *  Spec (per Vitus 2013-11, email to gryph-search with Excel spreadsheet attachment):
+   *   (007/00 = k AND  007/01 = h)  OR  300a contains "photograph"
+   */
 @Test
-	public void testPhoto()
-	{
-		String expVal = FormatPhysical.PHOTO.toString();
-		Leader ldr = factory.newLeader("01427ckm a2200265 a 4500");
-		Record record = factory.newRecord();
-		record.setLeader(ldr);
+  public void testPhoto()
+  {
+    String expVal = FormatPhysical.PHOTO.toString();
+    Leader ldr = factory.newLeader("01427ckm a2200265 a 4500");
+    Record record = factory.newRecord();
+    record.setLeader(ldr);
 
-		// 007/01 is not correct for Photo
-		cf007.setData("kj boo");
-		record.addVariableField(cf007);
-//		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-//		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.OTHER.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 0);
-		solrFldMapTest.assertNoSolrFld(record, physFormatFldName);
+    // 007/01 is not correct for Photo
+    cf007.setData("kj boo");
+    record.addVariableField(cf007);
+//    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+//    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.OTHER.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 0);
+    solrFldMapTest.assertNoSolrFld(record, physFormatFldName);
 
-		// 007/00 is k, 007/01 is h
-		record.removeVariableField(cf007);
-		cf007.setData("kh boo");
-		record.addVariableField(cf007);
-//		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-//		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.OTHER.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 0);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // 007/00 is k, 007/01 is h
+    record.removeVariableField(cf007);
+    cf007.setData("kh boo");
+    record.addVariableField(cf007);
+//    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+//    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.OTHER.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 0);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
 
-		// 300a contains photograph
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		DataField df300 = factory.newDataField("300", ' ', ' ');
-		df300.addSubfield(factory.newSubfield('a', "1 photograph (1 leaf)."));
-		record.addVariableField(df300);
-//		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-//		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.OTHER.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 0);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
-	}
+    // 300a contains photograph
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    DataField df300 = factory.newDataField("300", ' ', ' ');
+    df300.addSubfield(factory.newSubfield('a', "1 photograph (1 leaf)."));
+    record.addVariableField(df300);
+//    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+//    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.OTHER.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 0);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+  }
 
-	/**
-	 *  Spec (per Vitus 2013-11, email to gryph-search with Excel spreadsheet attachment):
-	 *   (007/00 = r)  OR  300a contains "remote-sensing image"
-	 */
+  /**
+   *  Spec (per Vitus 2013-11, email to gryph-search with Excel spreadsheet attachment):
+   *   (007/00 = r)  OR  300a contains "remote-sensing image"
+   */
 @Test
-	public void testRemoteSensingImage()
-	{
-		String expVal = FormatPhysical.REMOTE_SENSING_IMAGE.toString();
-		Leader ldr = factory.newLeader("01103cem a22002777a 4500");
-		Record record = factory.newRecord();
-		record.setLeader(ldr);
+  public void testRemoteSensingImage()
+  {
+    String expVal = FormatPhysical.REMOTE_SENSING_IMAGE.toString();
+    Leader ldr = factory.newLeader("01103cem a22002777a 4500");
+    Record record = factory.newRecord();
+    record.setLeader(ldr);
 
-		// 007/00 is not correct for Photo
-		cf007.setData("kj boo");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.MAP.toString());
-		solrFldMapTest.assertNoSolrFld(record, physFormatFldName);
+    // 007/00 is not correct for Photo
+    cf007.setData("kj boo");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.MAP.toString());
+    solrFldMapTest.assertNoSolrFld(record, physFormatFldName);
 
-		// 007/00 is r
-		record.removeVariableField(cf007);
-		cf007.setData("r  uuuuuuuu");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.MAP.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // 007/00 is r
+    record.removeVariableField(cf007);
+    cf007.setData("r  uuuuuuuu");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.MAP.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
 
-		// 300a contains remote sensing image  (no hyphen)
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		DataField df300 = factory.newDataField("300", ' ', ' ');
-		df300.addSubfield(factory.newSubfield('a', "1 remote sensing image ;"));
-		df300.addSubfield(factory.newSubfield('c', "18 x 20 cm."));
-		record.addVariableField(df300);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.MAP.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // 300a contains remote sensing image  (no hyphen)
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    DataField df300 = factory.newDataField("300", ' ', ' ');
+    df300.addSubfield(factory.newSubfield('a', "1 remote sensing image ;"));
+    df300.addSubfield(factory.newSubfield('c', "18 x 20 cm."));
+    record.addVariableField(df300);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.MAP.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
 
-		// 300a contains remote-sensing image  (with hyphen)
-		record.removeVariableField(df300);
-		df300 = factory.newDataField("300", ' ', ' ');
-		df300.addSubfield(factory.newSubfield('a', "remote-sensing images; "));
-		df300.addSubfield(factory.newSubfield('c', "on sheets 61 x 51 cm."));
-		record.addVariableField(df300);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.MAP.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
-	}
+    // 300a contains remote-sensing image  (with hyphen)
+    record.removeVariableField(df300);
+    df300 = factory.newDataField("300", ' ', ' ');
+    df300.addSubfield(factory.newSubfield('a', "remote-sensing images; "));
+    df300.addSubfield(factory.newSubfield('c', "on sheets 61 x 51 cm."));
+    record.addVariableField(df300);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.MAP.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+  }
 
 
 // ---------------------------- Recordings -----------------------------------
 
 @Test
-	public void testRecordingCD()
-	{
-		String expVal = FormatPhysical.CD.toString();
-		// based on 8833535
-		Leader ldr = factory.newLeader("02229cjm a2200409Ia 4500");
-		Record record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("sd fungnnmmneu");
-		record.addVariableField(cf007);
-		record.addVariableField(df999atLibrary);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, musicRecFormatVal);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
-		// not if online only
-		record.removeVariableField(df999atLibrary);
-		record.addVariableField(df999online);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
+  public void testRecordingCD()
+  {
+    String expVal = FormatPhysical.CD.toString();
+    // based on 8833535
+    Leader ldr = factory.newLeader("02229cjm a2200409Ia 4500");
+    Record record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("sd fungnnmmneu");
+    record.addVariableField(cf007);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, musicRecFormatVal);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // not if online only
+    record.removeVariableField(df999atLibrary);
+    record.addVariableField(df999online);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
 
-		// 007 but byte 3 is z   (Other)  (based on 5665607)    think there are about 1600 of these
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("sd zsngnnmmned");
-		record.addVariableField(cf007);
-		DataField df300 = factory.newDataField("300", ' ', ' ');
-		df300.addSubfield(factory.newSubfield('a', "1 sound disc :"));
-		df300.addSubfield(factory.newSubfield('b', "digital ;"));
-		df300.addSubfield(factory.newSubfield('c', "4 3/4 in."));
-		record.addVariableField(df300);
-		record.addVariableField(df999atLibrary);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, musicRecFormatVal);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
-		// not if online only
-		record.removeVariableField(df999atLibrary);
-		record.addVariableField(df999online);
+    // 007 but byte 3 is z   (Other)  (based on 5665607)    think there are about 1600 of these
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("sd zsngnnmmned");
+    record.addVariableField(cf007);
+    DataField df300 = factory.newDataField("300", ' ', ' ');
+    df300.addSubfield(factory.newSubfield('a', "1 sound disc :"));
+    df300.addSubfield(factory.newSubfield('b', "digital ;"));
+    df300.addSubfield(factory.newSubfield('c', "4 3/4 in."));
+    record.addVariableField(df300);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, musicRecFormatVal);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // not if online only
+    record.removeVariableField(df999atLibrary);
+    record.addVariableField(df999online);
 
-		// no 007, but 300  (based on 314009)  think there are about 1800 of these
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df300 = factory.newDataField("300", ' ', ' ');
-		df300.addSubfield(factory.newSubfield('a', "1 sound disc :"));
-		df300.addSubfield(factory.newSubfield('b', "digital ;"));
-		df300.addSubfield(factory.newSubfield('b', "4 3/4 in."));
-		record.addVariableField(df300);
-		record.addVariableField(df999atLibrary);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, musicRecFormatVal);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
-		// not if online only
-		record.removeVariableField(df999atLibrary);
-		record.addVariableField(df999online);
-	}
+    // no 007, but 300  (based on 314009)  think there are about 1800 of these
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df300 = factory.newDataField("300", ' ', ' ');
+    df300.addSubfield(factory.newSubfield('a', "1 sound disc :"));
+    df300.addSubfield(factory.newSubfield('b', "digital ;"));
+    df300.addSubfield(factory.newSubfield('b', "4 3/4 in."));
+    record.addVariableField(df300);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, musicRecFormatVal);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // not if online only
+    record.removeVariableField(df999atLibrary);
+    record.addVariableField(df999online);
+  }
 
 
-	/** test regex to find CD descriptions in 300 field */
+  /** test regex to find CD descriptions in 300 field */
 @Test
-	public void testDescribesCD()
-	{
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc (1 hr., 1 min.) : digital, stereo. ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc (1:06:59) : digital, stereo. ; 4 3/4 in. + pamphlet."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc (39:46) : digital, stereo. ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc (40 min., 29 sec.) : digital, stereo. ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc (43 min.) : digital, stereo. ; 4 3/4 in. + pamphlet."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc (43 min.) : digital, stereo. ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc (44 min.) digital, stereo. ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc (51 min.) : digital. ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc (68:57 min.) : digital, analog ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, chiefly mono. ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, monaural ; 4 3/4 in. + pamphlet."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, mono. ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, stereo ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, stereo. 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, stereo. ; 4 3/4 in. + booklet."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, stereo. ; 4 3/4 in. + pamphlet."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, stereo. ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("2 sound discs : digital ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("2 sound discs : digital, stereo. ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("2 sound discs : digital, stereo., HJ ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc (ca. 1 hr. 6 min.) : digital, stereo. ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("3 sound discs (ca. 151 min.) : digital ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("3 sound discs (ca. 2 hrs., 56 min.) : digital, stereo. ; 4 3/4 in. + 1 booklet (147 p.)."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, mono. ; c 4 3/4in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 compact sound disc : digital, stereo. ; 4 3/4 in."));
+  public void testDescribesCD()
+  {
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc (1 hr., 1 min.) : digital, stereo. ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc (1:06:59) : digital, stereo. ; 4 3/4 in. + pamphlet."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc (39:46) : digital, stereo. ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc (40 min., 29 sec.) : digital, stereo. ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc (43 min.) : digital, stereo. ; 4 3/4 in. + pamphlet."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc (43 min.) : digital, stereo. ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc (44 min.) digital, stereo. ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc (51 min.) : digital. ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc (68:57 min.) : digital, analog ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, chiefly mono. ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, monaural ; 4 3/4 in. + pamphlet."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, mono. ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, stereo ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, stereo. 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, stereo. ; 4 3/4 in. + booklet."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, stereo. ; 4 3/4 in. + pamphlet."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, stereo. ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("2 sound discs : digital ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("2 sound discs : digital, stereo. ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("2 sound discs : digital, stereo., HJ ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc (ca. 1 hr. 6 min.) : digital, stereo. ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("3 sound discs (ca. 151 min.) : digital ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("3 sound discs (ca. 2 hrs., 56 min.) : digital, stereo. ; 4 3/4 in. + 1 booklet (147 p.)."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, mono. ; c 4 3/4in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 compact sound disc : digital, stereo. ; 4 3/4 in."));
 
-		// look!  centimeters
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, mono. ; 12 cm."));
-		Assert.assertTrue(FormatUtils.describesCD("2 sound discs : digital, mono. ; 12 cm."));
-		Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital ; 12 cm."));
+    // look!  centimeters
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital, mono. ; 12 cm."));
+    Assert.assertTrue(FormatUtils.describesCD("2 sound discs : digital, mono. ; 12 cm."));
+    Assert.assertTrue(FormatUtils.describesCD("1 sound disc : digital ; 12 cm."));
 
-		// audio disc not sound disc
-		Assert.assertTrue(FormatUtils.describesCD("2 audio discs : digital, CD audio ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 audio disc : digital, CD audio, 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 audio disc : digital, CD audio, mono ; 4 3/4 in."));
+    // audio disc not sound disc
+    Assert.assertTrue(FormatUtils.describesCD("2 audio discs : digital, CD audio ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 audio disc : digital, CD audio, 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 audio disc : digital, CD audio, mono ; 4 3/4 in."));
 
-		// CD audio, not digital
-		Assert.assertTrue(FormatUtils.describesCD("1 audio disc : 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 audio disc : CD audio ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 audio disc : CD audio, 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 audio disc : CD-R, 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 audio disc : CD-R, CD audio ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 audio disc : digital ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 audio disc : digital, CD audio ; 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 audio disc : digital, CD audio, 4 3/4 in."));
-		Assert.assertTrue(FormatUtils.describesCD("1 audio disc : digital, CD audio, mono ; 4 3/4 in."));
+    // CD audio, not digital
+    Assert.assertTrue(FormatUtils.describesCD("1 audio disc : 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 audio disc : CD audio ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 audio disc : CD audio, 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 audio disc : CD-R, 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 audio disc : CD-R, CD audio ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 audio disc : digital ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 audio disc : digital, CD audio ; 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 audio disc : digital, CD audio, 4 3/4 in."));
+    Assert.assertTrue(FormatUtils.describesCD("1 audio disc : digital, CD audio, mono ; 4 3/4 in."));
 
-		// outliers
-//		Assert.assertTrue(FormatUtils.describesCD("1 sound disc ; 12 cm + 1 booklet (116 p.)."));
-//		Assert.assertTrue(FormatUtils.describesCD("1 sound disc (4 3/4 in.)"));
-//		Assert.assertTrue(FormatUtils.describesCD("1 sound disc : 500 rpm, stereo., digital ; 4 3/4 in."));
-//		Assert.assertTrue(FormatUtils.describesCD("1 disc (59 min.) : digital, stereo. ; 4 3/4 in. + 1 booklet."));
-//		Assert.assertTrue(FormatUtils.describesCD("127 p. : ill. (some col.), plans ; 24 cm. + 1 sound disc (digital : 4 3/4 in.)"));
-//		Assert.assertTrue(FormatUtils.describesCD("1 audio disc : CD audio"));
+    // outliers
+//    Assert.assertTrue(FormatUtils.describesCD("1 sound disc ; 12 cm + 1 booklet (116 p.)."));
+//    Assert.assertTrue(FormatUtils.describesCD("1 sound disc (4 3/4 in.)"));
+//    Assert.assertTrue(FormatUtils.describesCD("1 sound disc : 500 rpm, stereo., digital ; 4 3/4 in."));
+//    Assert.assertTrue(FormatUtils.describesCD("1 disc (59 min.) : digital, stereo. ; 4 3/4 in. + 1 booklet."));
+//    Assert.assertTrue(FormatUtils.describesCD("127 p. : ill. (some col.), plans ; 24 cm. + 1 sound disc (digital : 4 3/4 in.)"));
+//    Assert.assertTrue(FormatUtils.describesCD("1 audio disc : CD audio"));
 
-		// NOT
-		Assert.assertFalse(FormatUtils.describesCD("1 sound disc (6 hr.) : DVD audio, digital ; 4 3/4 in."));
-		Assert.assertFalse(FormatUtils.describesCD("1 sound disc : digital, DVD ; 4 3/4 in."));
-		Assert.assertFalse(FormatUtils.describesCD("1 sound disc : digital, DVD audio ; 4 3/4 in."));
-		Assert.assertFalse(FormatUtils.describesCD("1 sound disc : digital, DVD audio; 4 3/4 in."));
-		Assert.assertFalse(FormatUtils.describesCD("1 sound disc : digital, SACD ; 4 3/4 in. + 1 BluRay audio disc."));
-		Assert.assertFalse(FormatUtils.describesCD("1 online resource (1 sound file)"));
-		Assert.assertFalse(FormatUtils.describesCD("2s. 12in. 33.3rpm."));
-		Assert.assertFalse(FormatUtils.describesCD("1 sound disc : 33 1/3 rpm, stereo ; 12 in."));
-		Assert.assertFalse(FormatUtils.describesCD("1 sound disc : analog, 33 1/3 rpm, stereo. ; 12 in."));
-		Assert.assertFalse(FormatUtils.describesCD("1 sound disc : 33 1/3 rpm ; 12 in."));
-		Assert.assertFalse(FormatUtils.describesCD("1 sound disc (47 min) : analog, 33 1/3 rpm., stereo. ; 12 in."));
-	}
-
-
-@Test
-	public void testRecording78()
-	{
-		String expVal = FormatPhysical.SHELLAC_78.toString();
-		Leader ldr = factory.newLeader("01002cjm a2200313Ma 4500");
-		Record record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("sd dmsdnnmslne");
-		record.addVariableField(cf007);
-		record.addVariableField(df999atLibrary);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, musicRecFormatVal);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
-		// not if online only
-		record.removeVariableField(df999atLibrary);
-		record.addVariableField(df999online);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
-
-//		// no 007, but 300   (based on 8101257)    think there are about 200 of these
-//		record = factory.newRecord();
-//		record.addVariableField(df999atLibrary);
-//		DataField df300 = factory.newDataField("300", ' ', ' ');
-//		df300.addSubfield(factory.newSubfield('b', "78 rpm ;"));
-//		record.addVariableField(df300);
-//		solrFldMapTest.assertSolrFldValue(record, formatFldName, musicRecFormatVal);
-//		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-//		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
-//		// not if online only
-//		record.removeVariableField(df999atLibrary);
-//		record.addVariableField(df999online);
-	}
-
-@Test
-	public void testRecordingVinyl()
-	{
-		String expVal = FormatPhysical.VINYL.toString();
-		// based on 309570
-		Leader ldr = factory.newLeader("02683cjm a2200565ua 4500");
-		Record record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("sdubsmennmplue");
-		record.addVariableField(cf007);
-		record.addVariableField(df999atLibrary);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, musicRecFormatVal);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
-		// not if online only
-		record.removeVariableField(df999atLibrary);
-		record.addVariableField(df999online);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
-
-		// around 4000 have no 007 but have a 300  with 33 in it
-
-		// no 007, but 300 (based on 6594)   there are 873 of these, with this exact 300 value
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		DataField df300 = factory.newDataField("300", ' ', ' ');
-		df300.addSubfield(factory.newSubfield('a', "2s. 12in. 33.3rpm."));
-		record.addVariableField(df300);
-		record.addVariableField(df999atLibrary);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, musicRecFormatVal);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
-		// not if online only
-		record.removeVariableField(df999atLibrary);
-		record.addVariableField(df999online);
-
-		// (based on 307863)   500 with approx this 300 value
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df300 = factory.newDataField("300", ' ', ' ');
-		df300.addSubfield(factory.newSubfield('a', "1 sound disc :"));
-		df300.addSubfield(factory.newSubfield('b', "analog, 33 1/3 rpm, stereo. ;"));
-		df300.addSubfield(factory.newSubfield('c', "12 in."));
-		record.addVariableField(df300);
-		record.addVariableField(df999atLibrary);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, musicRecFormatVal);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
-		// not if online only
-		record.removeVariableField(df999atLibrary);
-		record.addVariableField(df999online);
-	}
-
-	/** test regex to find Vinyl 33 1/3 descriptions in 300 field */
-@Test
-	public void testDescribesVinyl()
-	{
-		// sorted
-		Assert.assertTrue(FormatUtils.describesVinyl("1 disc.  33 1/3 rpm. stereo. 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 disc.  33.3 rpm. stereo. 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 disc. 33 1/3 rpm.  quad. 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 disc. 33 1/3 rpm. 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 disc. 33 1/3 rpm. quad. 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 disc. 33 1/3 rpm. stereo. 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 s.  12 in.  33 1/3 rpm.  stereophonic."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 s. 12 in. 33 1/3 rpm. microgroove."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc (38 min.) : 33 1/3 rpm, mono. ; 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : 33 1/3 rpm ; 12 in. + insert."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : 33 1/3 rpm ; 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : 33 1/3 rpm, ; 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : 33 1/3 rpm, monaural ; 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : 33 1/3 rpm, stereo ; 12 in. + insert ([4] p.)"));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : 33 1/3 rpm, stereo. ; 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : analog, 33 1/3 rpm ; 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : analog, 33 1/3 rpm, mono. ; 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : analog, 33 1/3 rpm, stereo ; 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : analog, 33 1/3 rpm, stereo. ; 12 in. + insert."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc analog, 33 1/3 rpm, stereo. ; 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc: analog, stereo, 33 1/3 rpm, 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1-1/4s. 12in. 33.3rpm."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1/2 s. 12in. 33.3rpm. stereophonic."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1/2 s. 33 1/3 rpm. stereophonic. 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1/3s. 12in.  33.3rpm. stereophonic."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1/6s. 12in. 33.3rpm."));
-		Assert.assertTrue(FormatUtils.describesVinyl("10s. 12in. 33.3rpm."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1s. 10in. 33.3rpm."));
-		Assert.assertTrue(FormatUtils.describesVinyl("1s. 12in. 33.3rpm."));
-		Assert.assertTrue(FormatUtils.describesVinyl("2 discs. 33 1/3 rpm.  stereo. 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("2 discs. 33 1/3 rpm. stereo. 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("2 s.  12 in.  33 1/3 rpm.  microgroove.  stereophonic."));
-		Assert.assertTrue(FormatUtils.describesVinyl("2 s.  12 in.  33 1/3 rpm. stereophonic."));
-		Assert.assertTrue(FormatUtils.describesVinyl("2 s. 12 in. 33.3 rpm."));
-		Assert.assertTrue(FormatUtils.describesVinyl("2s.  12in.  33 1/3rpm. stereophonic."));
-		Assert.assertTrue(FormatUtils.describesVinyl("2s. 12in. 33 1/3rpm. stereophonic."));
-		Assert.assertTrue(FormatUtils.describesVinyl("3 discs. 33 1/3 rpm.  stereo. 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("4s.  12in.  33.3rpm. stereophonic."));
-		Assert.assertTrue(FormatUtils.describesVinyl("4s. 12in. 33.3rpm. stereophonic."));
-		Assert.assertTrue(FormatUtils.describesVinyl("5 sound discs : 33 1/3 rpm ; 12 in."));
-		Assert.assertTrue(FormatUtils.describesVinyl("on side 1 of 1 disc. 33 1/3 rpm. stereo. 12 in."));
-
-		// NOT
-		Assert.assertFalse(FormatUtils.describesVinyl("1 sound disc : digital ; 4 3/4 in."));
-		Assert.assertFalse(FormatUtils.describesVinyl("1 sound disc : digital, stereo. ; 4 3/4 in."));
-		Assert.assertFalse(FormatUtils.describesVinyl("1 videodisc (133 min.) : sd., col. ; 4 3/4 in."));
-		Assert.assertFalse(FormatUtils.describesVinyl("1 score (18 p.) ; 22 x 28 cm. + 4 parts ; 33 cm. + 1 sound disc (digital ; 4 3/4 in.)"));
-		Assert.assertFalse(FormatUtils.describesVinyl("1 sound disc (33 min.) : digital, stereo. ; 4 3/4 in."));
-		Assert.assertFalse(FormatUtils.describesVinyl("1 sound disc (6 hr.) : DVD audio, digital ; 4 3/4 in."));
-		Assert.assertFalse(FormatUtils.describesVinyl("1 sound disc : digital, DVD ; 4 3/4 in."));
-		Assert.assertFalse(FormatUtils.describesVinyl("1 sound disc : digital, DVD audio ; 4 3/4 in."));
-		Assert.assertFalse(FormatUtils.describesVinyl("1 sound disc : digital, DVD audio; 4 3/4 in."));
-		Assert.assertFalse(FormatUtils.describesVinyl("1 sound disc : digital, SACD ; 4 3/4 in. + 1 BluRay audio disc."));
-		Assert.assertFalse(FormatUtils.describesVinyl("1 online resource (1 sound file)"));
-	}
+    // NOT
+    Assert.assertFalse(FormatUtils.describesCD("1 sound disc (6 hr.) : DVD audio, digital ; 4 3/4 in."));
+    Assert.assertFalse(FormatUtils.describesCD("1 sound disc : digital, DVD ; 4 3/4 in."));
+    Assert.assertFalse(FormatUtils.describesCD("1 sound disc : digital, DVD audio ; 4 3/4 in."));
+    Assert.assertFalse(FormatUtils.describesCD("1 sound disc : digital, DVD audio; 4 3/4 in."));
+    Assert.assertFalse(FormatUtils.describesCD("1 sound disc : digital, SACD ; 4 3/4 in. + 1 BluRay audio disc."));
+    Assert.assertFalse(FormatUtils.describesCD("1 online resource (1 sound file)"));
+    Assert.assertFalse(FormatUtils.describesCD("2s. 12in. 33.3rpm."));
+    Assert.assertFalse(FormatUtils.describesCD("1 sound disc : 33 1/3 rpm, stereo ; 12 in."));
+    Assert.assertFalse(FormatUtils.describesCD("1 sound disc : analog, 33 1/3 rpm, stereo. ; 12 in."));
+    Assert.assertFalse(FormatUtils.describesCD("1 sound disc : 33 1/3 rpm ; 12 in."));
+    Assert.assertFalse(FormatUtils.describesCD("1 sound disc (47 min) : analog, 33 1/3 rpm., stereo. ; 12 in."));
+  }
 
 
 @Test
-	public void testRecordingCassette()
-	{
-		String expVal = FormatPhysical.CASSETTE.toString();
-		// with 007: based on 4730355
-		Leader ldr = factory.newLeader("01205cim a2200337Ia 4500");
-		Record record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("ss lunjlc-----");
-		record.addVariableField(cf007);
-		record.addVariableField(df999atLibrary);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.SOUND_RECORDING.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
-		// not if online only
-		record.removeVariableField(df999atLibrary);
-		record.addVariableField(df999online);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
+  public void testRecording78()
+  {
+    String expVal = FormatPhysical.SHELLAC_78.toString();
+    Leader ldr = factory.newLeader("01002cjm a2200313Ma 4500");
+    Record record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("sd dmsdnnmslne");
+    record.addVariableField(cf007);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, musicRecFormatVal);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // not if online only
+    record.removeVariableField(df999atLibrary);
+    record.addVariableField(df999online);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
 
-		// INDEX-134 Change Audio cassette to Audiocassette 
-		String oneWord = "Audiocassette";
-		// with 007: based on 4730355
-		ldr = factory.newLeader("01205cim a2200337Ia 4500");
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("ss lunjlc-----");
-		record.addVariableField(cf007);
-		record.addVariableField(df999atLibrary);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, oneWord);
-	
-	}
+//    // no 007, but 300   (based on 8101257)    think there are about 200 of these
+//    record = factory.newRecord();
+//    record.addVariableField(df999atLibrary);
+//    DataField df300 = factory.newDataField("300", ' ', ' ');
+//    df300.addSubfield(factory.newSubfield('b', "78 rpm ;"));
+//    record.addVariableField(df300);
+//    solrFldMapTest.assertSolrFldValue(record, formatFldName, musicRecFormatVal);
+//    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+//    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+//    // not if online only
+//    record.removeVariableField(df999atLibrary);
+//    record.addVariableField(df999online);
+  }
+
+@Test
+  public void testRecordingVinyl()
+  {
+    String expVal = FormatPhysical.VINYL.toString();
+    // based on 309570
+    Leader ldr = factory.newLeader("02683cjm a2200565ua 4500");
+    Record record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("sdubsmennmplue");
+    record.addVariableField(cf007);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, musicRecFormatVal);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // not if online only
+    record.removeVariableField(df999atLibrary);
+    record.addVariableField(df999online);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
+
+    // around 4000 have no 007 but have a 300  with 33 in it
+
+    // no 007, but 300 (based on 6594)   there are 873 of these, with this exact 300 value
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    DataField df300 = factory.newDataField("300", ' ', ' ');
+    df300.addSubfield(factory.newSubfield('a', "2s. 12in. 33.3rpm."));
+    record.addVariableField(df300);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, musicRecFormatVal);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // not if online only
+    record.removeVariableField(df999atLibrary);
+    record.addVariableField(df999online);
+
+    // (based on 307863)   500 with approx this 300 value
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df300 = factory.newDataField("300", ' ', ' ');
+    df300.addSubfield(factory.newSubfield('a', "1 sound disc :"));
+    df300.addSubfield(factory.newSubfield('b', "analog, 33 1/3 rpm, stereo. ;"));
+    df300.addSubfield(factory.newSubfield('c', "12 in."));
+    record.addVariableField(df300);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, musicRecFormatVal);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // not if online only
+    record.removeVariableField(df999atLibrary);
+    record.addVariableField(df999online);
+  }
+
+  /** test regex to find Vinyl 33 1/3 descriptions in 300 field */
+@Test
+  public void testDescribesVinyl()
+  {
+    // sorted
+    Assert.assertTrue(FormatUtils.describesVinyl("1 disc.  33 1/3 rpm. stereo. 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 disc.  33.3 rpm. stereo. 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 disc. 33 1/3 rpm.  quad. 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 disc. 33 1/3 rpm. 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 disc. 33 1/3 rpm. quad. 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 disc. 33 1/3 rpm. stereo. 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 s.  12 in.  33 1/3 rpm.  stereophonic."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 s. 12 in. 33 1/3 rpm. microgroove."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc (38 min.) : 33 1/3 rpm, mono. ; 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : 33 1/3 rpm ; 12 in. + insert."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : 33 1/3 rpm ; 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : 33 1/3 rpm, ; 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : 33 1/3 rpm, monaural ; 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : 33 1/3 rpm, stereo ; 12 in. + insert ([4] p.)"));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : 33 1/3 rpm, stereo. ; 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : analog, 33 1/3 rpm ; 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : analog, 33 1/3 rpm, mono. ; 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : analog, 33 1/3 rpm, stereo ; 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc : analog, 33 1/3 rpm, stereo. ; 12 in. + insert."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc analog, 33 1/3 rpm, stereo. ; 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1 sound disc: analog, stereo, 33 1/3 rpm, 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1-1/4s. 12in. 33.3rpm."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1/2 s. 12in. 33.3rpm. stereophonic."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1/2 s. 33 1/3 rpm. stereophonic. 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1/3s. 12in.  33.3rpm. stereophonic."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1/6s. 12in. 33.3rpm."));
+    Assert.assertTrue(FormatUtils.describesVinyl("10s. 12in. 33.3rpm."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1s. 10in. 33.3rpm."));
+    Assert.assertTrue(FormatUtils.describesVinyl("1s. 12in. 33.3rpm."));
+    Assert.assertTrue(FormatUtils.describesVinyl("2 discs. 33 1/3 rpm.  stereo. 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("2 discs. 33 1/3 rpm. stereo. 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("2 s.  12 in.  33 1/3 rpm.  microgroove.  stereophonic."));
+    Assert.assertTrue(FormatUtils.describesVinyl("2 s.  12 in.  33 1/3 rpm. stereophonic."));
+    Assert.assertTrue(FormatUtils.describesVinyl("2 s. 12 in. 33.3 rpm."));
+    Assert.assertTrue(FormatUtils.describesVinyl("2s.  12in.  33 1/3rpm. stereophonic."));
+    Assert.assertTrue(FormatUtils.describesVinyl("2s. 12in. 33 1/3rpm. stereophonic."));
+    Assert.assertTrue(FormatUtils.describesVinyl("3 discs. 33 1/3 rpm.  stereo. 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("4s.  12in.  33.3rpm. stereophonic."));
+    Assert.assertTrue(FormatUtils.describesVinyl("4s. 12in. 33.3rpm. stereophonic."));
+    Assert.assertTrue(FormatUtils.describesVinyl("5 sound discs : 33 1/3 rpm ; 12 in."));
+    Assert.assertTrue(FormatUtils.describesVinyl("on side 1 of 1 disc. 33 1/3 rpm. stereo. 12 in."));
+
+    // NOT
+    Assert.assertFalse(FormatUtils.describesVinyl("1 sound disc : digital ; 4 3/4 in."));
+    Assert.assertFalse(FormatUtils.describesVinyl("1 sound disc : digital, stereo. ; 4 3/4 in."));
+    Assert.assertFalse(FormatUtils.describesVinyl("1 videodisc (133 min.) : sd., col. ; 4 3/4 in."));
+    Assert.assertFalse(FormatUtils.describesVinyl("1 score (18 p.) ; 22 x 28 cm. + 4 parts ; 33 cm. + 1 sound disc (digital ; 4 3/4 in.)"));
+    Assert.assertFalse(FormatUtils.describesVinyl("1 sound disc (33 min.) : digital, stereo. ; 4 3/4 in."));
+    Assert.assertFalse(FormatUtils.describesVinyl("1 sound disc (6 hr.) : DVD audio, digital ; 4 3/4 in."));
+    Assert.assertFalse(FormatUtils.describesVinyl("1 sound disc : digital, DVD ; 4 3/4 in."));
+    Assert.assertFalse(FormatUtils.describesVinyl("1 sound disc : digital, DVD audio ; 4 3/4 in."));
+    Assert.assertFalse(FormatUtils.describesVinyl("1 sound disc : digital, DVD audio; 4 3/4 in."));
+    Assert.assertFalse(FormatUtils.describesVinyl("1 sound disc : digital, SACD ; 4 3/4 in. + 1 BluRay audio disc."));
+    Assert.assertFalse(FormatUtils.describesVinyl("1 online resource (1 sound file)"));
+  }
+
+
+@Test
+  public void testRecordingCassette()
+  {
+    String expVal = FormatPhysical.CASSETTE.toString();
+    // with 007: based on 4730355
+    Leader ldr = factory.newLeader("01205cim a2200337Ia 4500");
+    Record record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("ss lunjlc-----");
+    record.addVariableField(cf007);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.SOUND_RECORDING.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // not if online only
+    record.removeVariableField(df999atLibrary);
+    record.addVariableField(df999online);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
+
+    // INDEX-134 Change Audio cassette to Audiocassette
+    String oneWord = "Audiocassette";
+    // with 007: based on 4730355
+    ldr = factory.newLeader("01205cim a2200337Ia 4500");
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("ss lunjlc-----");
+    record.addVariableField(cf007);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, oneWord);
+
+  }
 
 /*
-	// recordings
-	VINYL_45,
-	WAX_CYLINDER,
-	INSTANTANEOUS_DISC,
-	CARTRIDGE_8_TRACK,
-	DAT,
+  // recordings
+  VINYL_45,
+  WAX_CYLINDER,
+  INSTANTANEOUS_DISC,
+  CARTRIDGE_8_TRACK,
+  DAT,
 
-	// maps
-	ATLAS,
-	GLOBE,
-	OTHER_MAPS,
+  // maps
+  ATLAS,
+  GLOBE,
+  OTHER_MAPS,
 
-	OTHER;
+  OTHER;
 */
 
-	// then do actual integration tests -- send record all the way through indexing
+  // then do actual integration tests -- send record all the way through indexing
 
 
-	/**
-	 *  Spec (per Vitus 2013-11, email to gryph-search with Excel spreadsheet attachment):
-	 *   (007/00 = h AND  007/01 = b,c,d,h or j)  OR  300a contains "microfilm"
-	 *    Naomi addition:  OR  if  callnum.startsWith("MFILM")
-	 *    Question:  (what if 245h has "microform" -- see 9646614 for example)
-	 */
+  /**
+   *  Spec (per Vitus 2013-11, email to gryph-search with Excel spreadsheet attachment):
+   *   (007/00 = h AND  007/01 = b,c,d,h or j)  OR  300a contains "microfilm"
+   *    Naomi addition:  OR  if  callnum.startsWith("MFILM")
+   *    Question:  (what if 245h has "microform" -- see 9646614 for example)
+   */
 @Test
-	public void testMicrofilm()
-	{
-		String expVal = FormatPhysical.MICROFILM.toString();
-		Leader ldr = factory.newLeader("01543cam a2200325Ka 4500");
-		Record record = factory.newRecord();
-		record.setLeader(ldr);
+  public void testMicrofilm()
+  {
+    String expVal = FormatPhysical.MICROFILM.toString();
+    Leader ldr = factory.newLeader("01543cam a2200325Ka 4500");
+    Record record = factory.newRecord();
+    record.setLeader(ldr);
 
-		// 007/01 is not correct for Microfilm
-		cf007.setData("ha afu   buca");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
-		solrFldMapTest.assertNoSolrFld(record, physFormatFldName);
+    // 007/01 is not correct for Microfilm
+    cf007.setData("ha afu   buca");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
+    solrFldMapTest.assertNoSolrFld(record, physFormatFldName);
 
-		// 007/01 is b
-		record.removeVariableField(cf007);
-		cf007.setData("hb afu   buca");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // 007/01 is b
+    record.removeVariableField(cf007);
+    cf007.setData("hb afu   buca");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
 
-		// 007/01 is c
-		record.removeVariableField(cf007);
-		cf007.setData("hc afu   buca");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // 007/01 is c
+    record.removeVariableField(cf007);
+    cf007.setData("hc afu   buca");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
 
-		// 007/01 is d
-		record.removeVariableField(cf007);
-		cf007.setData("hd afu   buca");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // 007/01 is d
+    record.removeVariableField(cf007);
+    cf007.setData("hd afu   buca");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
 
-		// 007/01 is h
-		record.removeVariableField(cf007);
-		cf007.setData("hh afu   buca");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // 007/01 is h
+    record.removeVariableField(cf007);
+    cf007.setData("hh afu   buca");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
 
-		// 007/01 is j
-		record.removeVariableField(cf007);
-		cf007.setData("hj afu   buca");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // 007/01 is j
+    record.removeVariableField(cf007);
+    cf007.setData("hj afu   buca");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
 
-		// callnum in 999
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		DataField df999 = factory.newDataField("999", ' ', ' ');
-		df999.addSubfield(factory.newSubfield('a', "MFILM N.S. 17443"));
-		df999.addSubfield(factory.newSubfield('w', "ALPHANUM"));
-		df999.addSubfield(factory.newSubfield('i', "9636901-1001"));
-		df999.addSubfield(factory.newSubfield('l', "MEDIA-MTXT"));
-		df999.addSubfield(factory.newSubfield('m', "GREEN"));
-		df999.addSubfield(factory.newSubfield('t', "NH-MICR"));
-		record.addVariableField(df999);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // callnum in 999
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    DataField df999 = factory.newDataField("999", ' ', ' ');
+    df999.addSubfield(factory.newSubfield('a', "MFILM N.S. 17443"));
+    df999.addSubfield(factory.newSubfield('w', "ALPHANUM"));
+    df999.addSubfield(factory.newSubfield('i', "9636901-1001"));
+    df999.addSubfield(factory.newSubfield('l', "MEDIA-MTXT"));
+    df999.addSubfield(factory.newSubfield('m', "GREEN"));
+    df999.addSubfield(factory.newSubfield('t', "NH-MICR"));
+    record.addVariableField(df999);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
 
-		// 300
-		record.removeVariableField(df999);
-		DataField df300 = factory.newDataField("300", ' ', ' ');
-		df300.addSubfield(factory.newSubfield('a', "21 microfilm reels ;"));
-		df300.addSubfield(factory.newSubfield('c', "35 mm."));
-		record.addVariableField(df300);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
-	}
+    // 300
+    record.removeVariableField(df999);
+    DataField df300 = factory.newDataField("300", ' ', ' ');
+    df300.addSubfield(factory.newSubfield('a', "21 microfilm reels ;"));
+    df300.addSubfield(factory.newSubfield('c', "35 mm."));
+    record.addVariableField(df300);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+  }
 
 
-	/**
-	 *  Spec (per Vitus 2013-11, email to gryph-search with Excel spreadsheet attachment):
-	 *   (007/00 = h AND  007/01 = e,f or g)  OR  300a contains "microfiche"
-	 *    Naomi addition:  OR  if  callnum.startsWith("MFICHE")
-	 *    Question:  (what if 245h has "microform" -- see 9646614 for example)
-	 */
+  /**
+   *  Spec (per Vitus 2013-11, email to gryph-search with Excel spreadsheet attachment):
+   *   (007/00 = h AND  007/01 = e,f or g)  OR  300a contains "microfiche"
+   *    Naomi addition:  OR  if  callnum.startsWith("MFICHE")
+   *    Question:  (what if 245h has "microform" -- see 9646614 for example)
+   */
 @Test
-	public void testMicrofiche()
-	{
-		String expVal = FormatPhysical.MICROFICHE.toString();
-		Leader ldr = factory.newLeader("01543cam a2200325Ka 4500");
-		Record record = factory.newRecord();
-		record.setLeader(ldr);
+  public void testMicrofiche()
+  {
+    String expVal = FormatPhysical.MICROFICHE.toString();
+    Leader ldr = factory.newLeader("01543cam a2200325Ka 4500");
+    Record record = factory.newRecord();
+    record.setLeader(ldr);
 
-		// 007/01 is not correct for Microfilm
-		cf007.setData("ha afu   buca");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
-		solrFldMapTest.assertNoSolrFld(record, physFormatFldName);
+    // 007/01 is not correct for Microfilm
+    cf007.setData("ha afu   buca");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
+    solrFldMapTest.assertNoSolrFld(record, physFormatFldName);
 
-		// 007/01 is e
-		record.removeVariableField(cf007);
-		cf007.setData("he bmb024bbca");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // 007/01 is e
+    record.removeVariableField(cf007);
+    cf007.setData("he bmb024bbca");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
 
-		// 007/01 is f
-		record.removeVariableField(cf007);
-		cf007.setData("hf bmb024bbca");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // 007/01 is f
+    record.removeVariableField(cf007);
+    cf007.setData("hf bmb024bbca");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
 
-		// 007/01 is g
-		record.removeVariableField(cf007);
-		cf007.setData("hg bmb024bbca");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // 007/01 is g
+    record.removeVariableField(cf007);
+    cf007.setData("hg bmb024bbca");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
 
-		// callnum in 999
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		DataField df999 = factory.newDataField("999", ' ', ' ');
-		df999.addSubfield(factory.newSubfield('a', "MFICHE 1183 N.5.1.7205"));
-		df999.addSubfield(factory.newSubfield('w', "ALPHANUM"));
-		df999.addSubfield(factory.newSubfield('i', "9664812-1001"));
-		df999.addSubfield(factory.newSubfield('l', "MEDIA-MTXT"));
-		df999.addSubfield(factory.newSubfield('m', "GREEN"));
-		df999.addSubfield(factory.newSubfield('t', "NH-MICR"));
-		record.addVariableField(df999);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+    // callnum in 999
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    DataField df999 = factory.newDataField("999", ' ', ' ');
+    df999.addSubfield(factory.newSubfield('a', "MFICHE 1183 N.5.1.7205"));
+    df999.addSubfield(factory.newSubfield('w', "ALPHANUM"));
+    df999.addSubfield(factory.newSubfield('i', "9664812-1001"));
+    df999.addSubfield(factory.newSubfield('l', "MEDIA-MTXT"));
+    df999.addSubfield(factory.newSubfield('m', "GREEN"));
+    df999.addSubfield(factory.newSubfield('t', "NH-MICR"));
+    record.addVariableField(df999);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
 
-		// 300
-		record.removeVariableField(df999);
-		DataField df300 = factory.newDataField("300", ' ', ' ');
-		df300.addSubfield(factory.newSubfield('a', "microfiches :"));
-		df300.addSubfield(factory.newSubfield('b', "ill. ;"));
-		df300.addSubfield(factory.newSubfield('c', "11 x 15 cm."));
-		record.addVariableField(df300);
-		solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
-	}
+    // 300
+    record.removeVariableField(df999);
+    DataField df300 = factory.newDataField("300", ' ', ' ');
+    df300.addSubfield(factory.newSubfield('a', "microfiches :"));
+    df300.addSubfield(factory.newSubfield('b', "ill. ;"));
+    df300.addSubfield(factory.newSubfield('c', "11 x 15 cm."));
+    record.addVariableField(df300);
+    solrFldMapTest.assertSolrFldHasNumValues(record, formatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, formatFldName, Format.BOOK.toString());
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, expVal);
+  }
 
-	/**
-	 *  Spec from email chain Nov 2013
-	 *  INDEX-89 - Video Physical Formats
-	 *  The order of checking for data
+  /**
+   *  Spec from email chain Nov 2013
+   *  INDEX-89 - Video Physical Formats
+   *  The order of checking for data
      *     i. call number
      *    ii. 538$a
      *   iii. 300$b and 347$b
      *   iv. 007
      * "Other video" not needed if there is a more specific value already determined
-	 **/
-	@Test
-	public void testVideo()
-	{
-		Leader ldr = factory.newLeader("04711cgm a2200733Ia 4500");
+   **/
+  @Test
+  public void testVideo()
+  {
+    Leader ldr = factory.newLeader("04711cgm a2200733Ia 4500");
 
-		// FILM - 007/00 = m
-		Record record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("ma afu   buca");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.FILM.toString());
-		
-		// DVD - call number starts with ZDVD
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		DataField df999 = factory.newDataField("999", ' ', ' ');
-		df999.addSubfield(factory.newSubfield('a', "ZDVD"));
-		record.addVariableField(df999);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.DVD.toString());
+    // FILM - 007/00 = m
+    Record record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("ma afu   buca");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.FILM.toString());
 
-		// DVD - call number starts with ARTDVD
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df999 = factory.newDataField("999", ' ', ' ');
-		df999.addSubfield(factory.newSubfield('a', "ARTDVD"));
-		record.addVariableField(df999);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.DVD.toString());
+    // DVD - call number starts with ZDVD
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    DataField df999 = factory.newDataField("999", ' ', ' ');
+    df999.addSubfield(factory.newSubfield('a', "ZDVD"));
+    record.addVariableField(df999);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.DVD.toString());
 
-		// DVD - call number starts with MDVD
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df999 = factory.newDataField("999", ' ', ' ');
-		df999.addSubfield(factory.newSubfield('a', "MDVD"));
-		record.addVariableField(df999);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.DVD.toString());
+    // DVD - call number starts with ARTDVD
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df999 = factory.newDataField("999", ' ', ' ');
+    df999.addSubfield(factory.newSubfield('a', "ARTDVD"));
+    record.addVariableField(df999);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.DVD.toString());
 
-		// DVD - call number starts with ADVD (for ARS)
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df999 = factory.newDataField("999", ' ', ' ');
-		df999.addSubfield(factory.newSubfield('a', "ADVD"));
-		record.addVariableField(df999);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.DVD.toString());
+    // DVD - call number starts with MDVD
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df999 = factory.newDataField("999", ' ', ' ');
+    df999.addSubfield(factory.newSubfield('a', "MDVD"));
+    record.addVariableField(df999);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.DVD.toString());
 
-		// DVD - 538 contains "DVD"
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		DataField df538 = factory.newDataField("538", ' ', ' ');
-		df538.addSubfield(factory.newSubfield('a', "DVD"));
-		record.addVariableField(df538);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.DVD.toString());
+    // DVD - call number starts with ADVD (for ARS)
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df999 = factory.newDataField("999", ' ', ' ');
+    df999.addSubfield(factory.newSubfield('a', "ADVD"));
+    record.addVariableField(df999);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.DVD.toString());
 
-		// DVD - 007/00 = v, 007/04 = v
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vd cvaizq");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.DVD.toString());
+    // DVD - 538 contains "DVD"
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    DataField df538 = factory.newDataField("538", ' ', ' ');
+    df538.addSubfield(factory.newSubfield('a', "DVD"));
+    record.addVariableField(df538);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.DVD.toString());
 
-		// DVD - 007/00 = v, 007/04 = z and 538$a contains DVD
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vd czaizq");
-		record.addVariableField(cf007);
-		df538 = factory.newDataField("538", ' ', ' ');
-		df538.addSubfield(factory.newSubfield('a', "DVD"));
-		record.addVariableField(df538);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.DVD.toString());
+    // DVD - 007/00 = v, 007/04 = v
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vd cvaizq");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.DVD.toString());
 
-		// BLURAY - call number contains "BLU-RAY"
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df999 = factory.newDataField("999", ' ', ' ');
-		df999.addSubfield(factory.newSubfield('a', "ZDVD 12345 BLU-RAY"));
-		record.addVariableField(df999);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.BLURAY.toString());
-		
-		// BLURAY - 538 contains "Bluray"
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df538 = factory.newDataField("538", ' ', ' ');
-		df538.addSubfield(factory.newSubfield('a', "Bluray"));
-		record.addVariableField(df538);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.BLURAY.toString());
+    // DVD - 007/00 = v, 007/04 = z and 538$a contains DVD
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vd czaizq");
+    record.addVariableField(cf007);
+    df538 = factory.newDataField("538", ' ', ' ');
+    df538.addSubfield(factory.newSubfield('a', "DVD"));
+    record.addVariableField(df538);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.DVD.toString());
 
-		// BLURAY - 538 contains "Blu ray"
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df538 = factory.newDataField("538", ' ', ' ');
-		df538.addSubfield(factory.newSubfield('a', "Blu ray"));
-		record.addVariableField(df538);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.BLURAY.toString());
+    // BLURAY - call number contains "BLU-RAY"
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df999 = factory.newDataField("999", ' ', ' ');
+    df999.addSubfield(factory.newSubfield('a', "ZDVD 12345 BLU-RAY"));
+    record.addVariableField(df999);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.BLURAY.toString());
 
-		// BLURAY - 538 contains "Blu-ray"
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df538 = factory.newDataField("538", ' ', ' ');
-		df538.addSubfield(factory.newSubfield('a', "Blu-ray"));
-		record.addVariableField(df538);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.BLURAY.toString());
+    // BLURAY - 538 contains "Bluray"
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df538 = factory.newDataField("538", ' ', ' ');
+    df538.addSubfield(factory.newSubfield('a', "Bluray"));
+    record.addVariableField(df538);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.BLURAY.toString());
 
-		// BLURAY - 007/00 = v, 007/04 = s
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vd csaizq");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.BLURAY.toString());
+    // BLURAY - 538 contains "Blu ray"
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df538 = factory.newDataField("538", ' ', ' ');
+    df538.addSubfield(factory.newSubfield('a', "Blu ray"));
+    record.addVariableField(df538);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.BLURAY.toString());
 
-		// VHS - call number starts with ZVC
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df999 = factory.newDataField("999", ' ', ' ');
-		df999.addSubfield(factory.newSubfield('a', "ZVC"));
-		record.addVariableField(df999);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VHS.toString());
+    // BLURAY - 538 contains "Blu-ray"
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df538 = factory.newDataField("538", ' ', ' ');
+    df538.addSubfield(factory.newSubfield('a', "Blu-ray"));
+    record.addVariableField(df538);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.BLURAY.toString());
 
-		// VHS - call number starts with ARTVC
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df999 = factory.newDataField("999", ' ', ' ');
-		df999.addSubfield(factory.newSubfield('a', "ARTVC"));
-		record.addVariableField(df999);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VHS.toString());
+    // BLURAY - 007/00 = v, 007/04 = s
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vd csaizq");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.BLURAY.toString());
 
-		// VHS - call number starts with MVC
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df999 = factory.newDataField("999", ' ', ' ');
-		df999.addSubfield(factory.newSubfield('a', "MVC"));
-		record.addVariableField(df999);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VHS.toString());
-		
-		// VHS - call number starts with AVC (for ARS)
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df999 = factory.newDataField("999", ' ', ' ');
-		df999.addSubfield(factory.newSubfield('a', "AVC"));
-		record.addVariableField(df999);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEOCASSETTE.toString());
+    // VHS - call number starts with ZVC
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df999 = factory.newDataField("999", ' ', ' ');
+    df999.addSubfield(factory.newSubfield('a', "ZVC"));
+    record.addVariableField(df999);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VHS.toString());
 
-		// VHS - 538 contains "VHS"
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df538 = factory.newDataField("538", ' ', ' ');
-		df538.addSubfield(factory.newSubfield('a', "VHS"));
-		record.addVariableField(df538);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VHS.toString());
+    // VHS - call number starts with ARTVC
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df999 = factory.newDataField("999", ' ', ' ');
+    df999.addSubfield(factory.newSubfield('a', "ARTVC"));
+    record.addVariableField(df999);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VHS.toString());
 
-		// VHS - 007/00 = v, 007/04 = b
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vb cbsaizq");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VHS.toString());
+    // VHS - call number starts with MVC
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df999 = factory.newDataField("999", ' ', ' ');
+    df999.addSubfield(factory.newSubfield('a', "MVC"));
+    record.addVariableField(df999);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VHS.toString());
 
-		// BETA - 007/00 = v,  and 007/04 = a 
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vb vaaizq");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.BETA.toString());
+    // VHS - call number starts with AVC (for ARS)
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df999 = factory.newDataField("999", ' ', ' ');
+    df999.addSubfield(factory.newSubfield('a', "AVC"));
+    record.addVariableField(df999);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEOCASSETTE.toString());
 
-		// MP4 - 007/00 = v, 300$b = MP4
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		DataField df300 = factory.newDataField("300", ' ', ' ');
-		df300.addSubfield(factory.newSubfield('b', "MP4"));
-		record.addVariableField(df300);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.MP4.toString());
-		solrFldMapTest.assertSolrFldHasNoValue(record, physFormatFldName, FormatPhysical.OTHER_VIDEO.toString());
-		
-		// MP4 - 007/00 = v, 347$b = MPEG-4
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		DataField df347 = factory.newDataField("347", ' ', ' ');
-		df347.addSubfield(factory.newSubfield('b', "MPEG-4"));
-		record.addVariableField(df347);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.MP4.toString());
-		solrFldMapTest.assertSolrFldHasNoValue(record, physFormatFldName, FormatPhysical.OTHER_VIDEO.toString());
-		
-		// Hi-8 mm - 007/00 = v, 007/04 = q
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vb vqaizq");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.HI_8.toString());
+    // VHS - 538 contains "VHS"
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df538 = factory.newDataField("538", ' ', ' ');
+    df538.addSubfield(factory.newSubfield('a', "VHS"));
+    record.addVariableField(df538);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VHS.toString());
 
-		// 007/00 != v or m
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("    vaizq");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertNoSolrFld(record, physFormatFldName);
+    // VHS - 007/00 = v, 007/04 = b
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vb cbsaizq");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VHS.toString());
 
-		// OTHER_VIDEO - 007/00 = v but 007/04 != a, b, i, j, q, s, v  and no 300, 347, and 538 
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("v   zxaizq");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.OTHER_VIDEO.toString());
+    // BETA - 007/00 = v,  and 007/04 = a
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vb vaaizq");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.BETA.toString());
 
-		// Not MP4 from 300$b or 347$b
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("    vaizq");
-		record.addVariableField(cf007);
-		df300 = factory.newDataField("300", ' ', ' ');
-		df300.addSubfield(factory.newSubfield('b', "M"));
-		record.addVariableField(df300);
-		df347 = factory.newDataField("347", ' ', ' ');
-		df347.addSubfield(factory.newSubfield('b', "M"));
-		record.addVariableField(df347);
-		solrFldMapTest.assertSolrFldHasNoValue(record, physFormatFldName, FormatPhysical.MP4.toString());
-		solrFldMapTest.assertNoSolrFld(record, physFormatFldName);
-		
-		// not BLURAY or VHS - 538 does not contain "Bluray" or "VHS"
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df538 = factory.newDataField("538", ' ', ' ');
-		df538.addSubfield(factory.newSubfield('a', "Junk"));
-		record.addVariableField(df538);
-		solrFldMapTest.assertSolrFldHasNoValue(record, physFormatFldName, FormatPhysical.VHS.toString());
-		solrFldMapTest.assertSolrFldHasNoValue(record, physFormatFldName, FormatPhysical.BLURAY.toString());
+    // MP4 - 007/00 = v, 300$b = MP4
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    DataField df300 = factory.newDataField("300", ' ', ' ');
+    df300.addSubfield(factory.newSubfield('b', "MP4"));
+    record.addVariableField(df300);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.MP4.toString());
+    solrFldMapTest.assertSolrFldHasNoValue(record, physFormatFldName, FormatPhysical.OTHER_VIDEO.toString());
 
-		// Laser disc - call number starts with ZVD
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df999 = factory.newDataField("999", ' ', ' ');
-		df999.addSubfield(factory.newSubfield('a', "ZVD"));
-		record.addVariableField(df999);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.LASER_DISC.toString());
+    // MP4 - 007/00 = v, 347$b = MPEG-4
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    DataField df347 = factory.newDataField("347", ' ', ' ');
+    df347.addSubfield(factory.newSubfield('b', "MPEG-4"));
+    record.addVariableField(df347);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.MP4.toString());
+    solrFldMapTest.assertSolrFldHasNoValue(record, physFormatFldName, FormatPhysical.OTHER_VIDEO.toString());
 
-		// Laser disc - call number starts with MVD
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df999 = factory.newDataField("999", ' ', ' ');
-		df999.addSubfield(factory.newSubfield('a', "MVD"));
-		record.addVariableField(df999);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.LASER_DISC.toString());
-		
-		// Laser disc - 538$a contains CAV
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df538 = factory.newDataField("538", ' ', ' ');
-		df538.addSubfield(factory.newSubfield('a', "CAV"));
-		record.addVariableField(df538);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.LASER_DISC.toString());
+    // Hi-8 mm - 007/00 = v, 007/04 = q
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vb vqaizq");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.HI_8.toString());
 
-		// Laser disc - 538$a contains CLV
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		df538 = factory.newDataField("538", ' ', ' ');
-		df538.addSubfield(factory.newSubfield('a', "CLV"));
-		record.addVariableField(df538);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.LASER_DISC.toString());
+    // 007/00 != v or m
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("    vaizq");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertNoSolrFld(record, physFormatFldName);
 
-		// Laser disc - 007/00 - v, 007/04 = g
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vb vgaizq");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.LASER_DISC.toString());
+    // OTHER_VIDEO - 007/00 = v but 007/04 != a, b, i, j, q, s, v  and no 300, 347, and 538
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("v   zxaizq");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.OTHER_VIDEO.toString());
 
-		// Laser disc - 007/00 - v, 007/04 = z 538$a contains CAV
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vd czaizq");
-		record.addVariableField(cf007);
-		df538 = factory.newDataField("538", ' ', ' ');
-		df538.addSubfield(factory.newSubfield('a', "CAV"));
-		record.addVariableField(df538);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.LASER_DISC.toString());
+    // Not MP4 from 300$b or 347$b
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("    vaizq");
+    record.addVariableField(cf007);
+    df300 = factory.newDataField("300", ' ', ' ');
+    df300.addSubfield(factory.newSubfield('b', "M"));
+    record.addVariableField(df300);
+    df347 = factory.newDataField("347", ' ', ' ');
+    df347.addSubfield(factory.newSubfield('b', "M"));
+    record.addVariableField(df347);
+    solrFldMapTest.assertSolrFldHasNoValue(record, physFormatFldName, FormatPhysical.MP4.toString());
+    solrFldMapTest.assertNoSolrFld(record, physFormatFldName);
 
-		// Laser disc - 007/00 - v, 007/04 = z 538$a contains CLV
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vd czaizq");
-		record.addVariableField(cf007);
-		df538 = factory.newDataField("538", ' ', ' ');
-		df538.addSubfield(factory.newSubfield('a', "CLV"));
-		record.addVariableField(df538);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.LASER_DISC.toString());
+    // not BLURAY or VHS - 538 does not contain "Bluray" or "VHS"
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df538 = factory.newDataField("538", ' ', ' ');
+    df538.addSubfield(factory.newSubfield('a', "Junk"));
+    record.addVariableField(df538);
+    solrFldMapTest.assertSolrFldHasNoValue(record, physFormatFldName, FormatPhysical.VHS.toString());
+    solrFldMapTest.assertSolrFldHasNoValue(record, physFormatFldName, FormatPhysical.BLURAY.toString());
 
-		// Video CD - 007/00 = v and 007/04 = z and 538a contains VCD
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vd czaizq");
-		record.addVariableField(cf007);
-		df538 = factory.newDataField("538", ' ', ' ');
-		df538.addSubfield(factory.newSubfield('a', "VCD"));
-		record.addVariableField(df538);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
+    // Laser disc - call number starts with ZVD
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df999 = factory.newDataField("999", ' ', ' ');
+    df999.addSubfield(factory.newSubfield('a', "ZVD"));
+    record.addVariableField(df999);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.LASER_DISC.toString());
 
-		// Video CD - 007/00 = v and 007/04 = z and 538a contains Video CD
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vd czaizq");
-		record.addVariableField(cf007);
-		df538 = factory.newDataField("538", ' ', ' ');
-		df538.addSubfield(factory.newSubfield('a', "Video CD"));
-		record.addVariableField(df538);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
+    // Laser disc - call number starts with MVD
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df999 = factory.newDataField("999", ' ', ' ');
+    df999.addSubfield(factory.newSubfield('a', "MVD"));
+    record.addVariableField(df999);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.LASER_DISC.toString());
 
-		// Video CD - 007/00 = v and 007/04 = z and 538a contains VideoCD
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vd czaizq");
-		record.addVariableField(cf007);
-		df538 = factory.newDataField("538", ' ', ' ');
-		df538.addSubfield(factory.newSubfield('a', "VideoCD"));
-		record.addVariableField(df538);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
+    // Laser disc - 538$a contains CAV
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df538 = factory.newDataField("538", ' ', ' ');
+    df538.addSubfield(factory.newSubfield('a', "CAV"));
+    record.addVariableField(df538);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.LASER_DISC.toString());
 
-		// Video CD - 007/00 = v and 007/04 = z and 300b contains VCD
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vd czaizq");
-		record.addVariableField(cf007);
-		df300 = factory.newDataField("300", ' ', ' ');
-		df300.addSubfield(factory.newSubfield('b', "VCD"));
-		record.addVariableField(df300);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
+    // Laser disc - 538$a contains CLV
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df538 = factory.newDataField("538", ' ', ' ');
+    df538.addSubfield(factory.newSubfield('a', "CLV"));
+    record.addVariableField(df538);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.LASER_DISC.toString());
 
-		// Video CD - 007/00 = v and 007/04 = z and 300b contains Video CD
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vd czaizq");
-		record.addVariableField(cf007);
-		df300 = factory.newDataField("300", ' ', ' ');
-		df300.addSubfield(factory.newSubfield('b', "Video CD"));
-		record.addVariableField(df300);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
+    // Laser disc - 007/00 - v, 007/04 = g
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vb vgaizq");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.LASER_DISC.toString());
 
-		// Video CD - 007/00 = v and 007/04 = z and 300b contains VideoCD
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vd czaizq");
-		record.addVariableField(cf007);
-		df300 = factory.newDataField("300", ' ', ' ');
-		df300.addSubfield(factory.newSubfield('b', "VideoCD"));
-		record.addVariableField(df300);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
+    // Laser disc - 007/00 - v, 007/04 = z 538$a contains CAV
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vd czaizq");
+    record.addVariableField(cf007);
+    df538 = factory.newDataField("538", ' ', ' ');
+    df538.addSubfield(factory.newSubfield('a', "CAV"));
+    record.addVariableField(df538);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.LASER_DISC.toString());
 
-		// Video CD - 007/00 = v and 007/04 = z and 347b contains VCD
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vd czaizq");
-		record.addVariableField(cf007);
-		df347 = factory.newDataField("347", ' ', ' ');
-		df347.addSubfield(factory.newSubfield('b', "VCD"));
-		record.addVariableField(df347);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
+    // Laser disc - 007/00 - v, 007/04 = z 538$a contains CLV
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vd czaizq");
+    record.addVariableField(cf007);
+    df538 = factory.newDataField("538", ' ', ' ');
+    df538.addSubfield(factory.newSubfield('a', "CLV"));
+    record.addVariableField(df538);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.LASER_DISC.toString());
 
-		// Video CD - 007/00 = v and 007/04 = z and 347b contains Video CD
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vd czaizq");
-		record.addVariableField(cf007);
-		df347 = factory.newDataField("347", ' ', ' ');
-		df347.addSubfield(factory.newSubfield('b', "Video CD"));
-		record.addVariableField(df347);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
+    // Video CD - 007/00 = v and 007/04 = z and 538a contains VCD
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vd czaizq");
+    record.addVariableField(cf007);
+    df538 = factory.newDataField("538", ' ', ' ');
+    df538.addSubfield(factory.newSubfield('a', "VCD"));
+    record.addVariableField(df538);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
 
-		// Video CD - 007/00 = v and 007/04 = z and 347b contains VideoCD
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vd czaizq");
-		record.addVariableField(cf007);
-		df347 = factory.newDataField("347", ' ', ' ');
-		df347.addSubfield(factory.newSubfield('b', "VideoCD"));
-		record.addVariableField(df347);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
-		
-		// Other Video because nothing in 538$a, 300$b, 347$b
-		record = factory.newRecord();
-		record.setLeader(ldr);
-		cf007.setData("vd czaizq");
-		record.addVariableField(cf007);
-		solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.OTHER_VIDEO.toString());
+    // Video CD - 007/00 = v and 007/04 = z and 538a contains Video CD
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vd czaizq");
+    record.addVariableField(cf007);
+    df538 = factory.newDataField("538", ' ', ' ');
+    df538.addSubfield(factory.newSubfield('a', "Video CD"));
+    record.addVariableField(df538);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
 
-	}
+    // Video CD - 007/00 = v and 007/04 = z and 538a contains VideoCD
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vd czaizq");
+    record.addVariableField(cf007);
+    df538 = factory.newDataField("538", ' ', ' ');
+    df538.addSubfield(factory.newSubfield('a', "VideoCD"));
+    record.addVariableField(df538);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
+
+    // Video CD - 007/00 = v and 007/04 = z and 300b contains VCD
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vd czaizq");
+    record.addVariableField(cf007);
+    df300 = factory.newDataField("300", ' ', ' ');
+    df300.addSubfield(factory.newSubfield('b', "VCD"));
+    record.addVariableField(df300);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
+
+    // Video CD - 007/00 = v and 007/04 = z and 300b contains Video CD
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vd czaizq");
+    record.addVariableField(cf007);
+    df300 = factory.newDataField("300", ' ', ' ');
+    df300.addSubfield(factory.newSubfield('b', "Video CD"));
+    record.addVariableField(df300);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
+
+    // Video CD - 007/00 = v and 007/04 = z and 300b contains VideoCD
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vd czaizq");
+    record.addVariableField(cf007);
+    df300 = factory.newDataField("300", ' ', ' ');
+    df300.addSubfield(factory.newSubfield('b', "VideoCD"));
+    record.addVariableField(df300);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
+
+    // Video CD - 007/00 = v and 007/04 = z and 347b contains VCD
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vd czaizq");
+    record.addVariableField(cf007);
+    df347 = factory.newDataField("347", ' ', ' ');
+    df347.addSubfield(factory.newSubfield('b', "VCD"));
+    record.addVariableField(df347);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
+
+    // Video CD - 007/00 = v and 007/04 = z and 347b contains Video CD
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vd czaizq");
+    record.addVariableField(cf007);
+    df347 = factory.newDataField("347", ' ', ' ');
+    df347.addSubfield(factory.newSubfield('b', "Video CD"));
+    record.addVariableField(df347);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
+
+    // Video CD - 007/00 = v and 007/04 = z and 347b contains VideoCD
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vd czaizq");
+    record.addVariableField(cf007);
+    df347 = factory.newDataField("347", ' ', ' ');
+    df347.addSubfield(factory.newSubfield('b', "VideoCD"));
+    record.addVariableField(df347);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.VIDEO_CD.toString());
+
+    // Other Video because nothing in 538$a, 300$b, 347$b
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("vd czaizq");
+    record.addVariableField(cf007);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.OTHER_VIDEO.toString());
+
+  }
+
+  /**
+   *  SW-1531 - Piano Organ roll value
+   *  if 007/00 = 's' and 007/01 = 'q' or
+   *  if 338$a or 300$a contains "audio roll"
+   *
+   **/
+  @Test
+  public void testPianoOrganRoll()
+  {
+    Leader ldr = factory.newLeader("01103cem a22002777a 4500");
+    // 007/00 = s, 007/01 = q
+    Record record = factory.newRecord();
+    record.setLeader(ldr);
+    cf007.setData("sq     ");
+    record.addVariableField(cf007);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.PIANO_ORGAN_ROLL.toString());
+
+    // 300$a contains "audio roll"
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    DataField df300 = factory.newDataField("300", ' ', ' ');
+    df300.addSubfield(factory.newSubfield('a', "1 audio roll"));
+    record.addVariableField(df300);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.PIANO_ORGAN_ROLL.toString());
+
+    // 338$a contains "audio roll"
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    DataField df338 = factory.newDataField("338", ' ', ' ');
+    df338.addSubfield(factory.newSubfield('a', "1 audio roll"));
+    record.addVariableField(df338);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 1);
+    solrFldMapTest.assertSolrFldValue(record, physFormatFldName, FormatPhysical.PIANO_ORGAN_ROLL.toString());
+
+    // 338$a contains "audio and roll" so no Piano/organ roll media type
+    record = factory.newRecord();
+    record.setLeader(ldr);
+    df338 = factory.newDataField("338", ' ', ' ');
+    df338.addSubfield(factory.newSubfield('a', "1 audio and roll"));
+    record.addVariableField(df338);
+    record.addVariableField(df999atLibrary);
+    solrFldMapTest.assertSolrFldHasNumValues(record, physFormatFldName, 0);
+    solrFldMapTest.assertSolrFldHasNoValue(record, physFormatFldName, FormatPhysical.PIANO_ORGAN_ROLL.toString());
+
+  }
 
 }


### PR DESCRIPTION
@jkeck @aeschylus 
Because it is hard to see the modifications in the differences below, here is a description with line numbers:
1. Modified FormatUtils.java by adding line 492-492 and 599-603 based on this spec:

338$a or 300$a with "audio roll" or 007/00 = 's' and 007/01 = ‘q'
1. Added enum (PIANO_ORGAN_ROLL) and value to FormatPhysical.java - 
   
     case PIANO_ORGAN_ROLL:
       return "Piano/organ roll";
2. Added tests to FormatPhysicalTests.java starting from 1205 to the end of the file.
