### PR TITLE
solrconfig returns pub_year_ss instead of pub_date_display

### DIFF
--- a/stanford-sw/solr/conf/schema.xml
+++ b/stanford-sw/solr/conf/schema.xml
@@ -150,7 +150,6 @@
     <field name="pub_date" type="string" indexed="true" stored="true" />
     <field name="pub_year_tisim" type="tint" indexed="true" stored="false" multiValued="true" />
     <field name="pub_display" type="string" indexed="false" stored="true" multiValued="true"/>
-    <field name="pub_date_display" type="string" indexed="false" stored="true"/>
     <field name="imprint_display" type="string" indexed="false" stored="true" multiValued="true"/>
 
     <!-- Date Cataloged for new items feed -->

--- a/stanford-sw/solr/conf/solrconfig-ext-test.xml
+++ b/stanford-sw/solr/conf/solrconfig-ext-test.xml
@@ -900,7 +900,7 @@
         production_year_isi,
         original_year_isi,
         copyright_year_isi,
-        pub_date_display,
+        pub_year_ss,
         summary_display,
         title_245a_display,           vern_title_245a_display,
         title_245c_display,           vern_title_245c_display,

--- a/stanford-sw/solr/conf/solrconfig-no-repl.xml
+++ b/stanford-sw/solr/conf/solrconfig-no-repl.xml
@@ -964,7 +964,7 @@
         production_year_isi,
         original_year_isi,
         copyright_year_isi,
-        pub_date_display,
+        pub_year_ss,
         summary_display,
         title_245a_display,           vern_title_245a_display,
         title_245c_display,           vern_title_245c_display,

--- a/stanford-sw/solr/conf/solrconfig-slave.xml
+++ b/stanford-sw/solr/conf/solrconfig-slave.xml
@@ -976,7 +976,7 @@
         production_year_isi,
         original_year_isi,
         copyright_year_isi,
-        pub_date_display,
+        pub_year_ss,
         summary_display,
         title_245a_display,           vern_title_245a_display,
         title_245c_display,           vern_title_245c_display,

--- a/stanford-sw/test/src/edu/stanford/PublicationTests.java
+++ b/stanford-sw/test/src/edu/stanford/PublicationTests.java
@@ -1532,7 +1532,7 @@ public class PublicationTests extends AbstractStanfordTest
 
 
 	/**
-	 * functional test: pub_date_display field
+	 * functional test: pub_date field (which is @deprecated)
 	 */
 @Test
 	public final void testPubDateForDisplay()


### PR DESCRIPTION
pub_date_display is defunct;  not used by SW app code and not indexed to

pub_year_ss need to be in search results

@lmcglohon 
