### PR TITLE
remove defunct Solr fields date_xxx_raw_ssi(m)

### DIFF
--- a/stanford-sw/sw_index.properties
+++ b/stanford-sw/sw_index.properties
@@ -98,8 +98,6 @@ pub_date = custom, getPubDate
 pub_date_sort = custom, getPubDateSort
 pub_year_tisim = custom, getPubDateSliderVals
 # from 008 date 1
-# for debugging date slider
-date_1_008_raw_ssi = 008[7-10]
 publication_year_isi = custom, get008Date1(est)
 beginning_year_isi = custom, get008Date1(cdmu)
 earliest_year_isi = custom, get008Date1(ik)
@@ -108,8 +106,6 @@ release_year_isi = custom, get008Date1(p)
 reprint_year_isi = custom, get008Date1(r)
 other_year_isi = custom, getOtherYear
 # from 008 date 2
-# for debugging date slider
-date_2_008_raw_ssi = 008[11-14]
 ending_year_isi = custom, get008Date2(dm)
 latest_year_isi = custom, get008Date2(ik)
 latest_poss_year_isi = custom, get008Date2(q)
@@ -117,12 +113,7 @@ production_year_isi = custom, get008Date2(p)
 original_year_isi = custom, get008Date2(r)
 copyright_year_isi = custom, get008Date2(t)
 # from 260c
-# for debugging date slider
-date_260c_raw_ssim = 260c
 imprint_display = custom, getImprint
-# from 264c, based on indicators
-# for debugging date slider
-date_264c_raw_ssim = 264c
 
 # Date field for new items feed
 date_cataloged = custom, getDateCataloged

--- a/stanford-sw/test/src/edu/stanford/PublicationTests.java
+++ b/stanford-sw/test/src/edu/stanford/PublicationTests.java
@@ -1624,8 +1624,6 @@ public class PublicationTests extends AbstractStanfordTest
 	{
 		Record record = factory.newRecord();
 		record.addVariableField(factory.newControlField("008", "      " + byte06 + date1str + date2str));
-		solrFldMapTest.assertSolrFldValue(record, "date_1_008_raw_ssi", date1str);
-		solrFldMapTest.assertSolrFldValue(record, "date_2_008_raw_ssi", date2str);
 	    solrFldMapTest.assertNoSolrFld(record, "beginning_year_isi");
 	    solrFldMapTest.assertNoSolrFld(record, "earliest_year_isi");
 	    solrFldMapTest.assertNoSolrFld(record, "earliest_poss_year_isi");


### PR DESCRIPTION
@lmcglohon 

These fields are not used anywhere and have been removed from indexing:

date_1_008_raw_ssi
date_2_008_raw_ssi
date_260c_raw_ssim
date_264c_raw_ssim

closes #5
