### PR TITLE
Indexes records in a closed library by reserves library

### DIFF
--- a/stanford-sw/src/edu/stanford/Item.java
+++ b/stanford-sw/src/edu/stanford/Item.java
@@ -14,545 +14,548 @@ import edu.stanford.enumValues.CallNumberType;
  */
 public class Item {
 
-	/** call number for SUL online items */
-	public final static String ECALLNUM = "INTERNET RESOURCE";
-	/** location code for online items */
-	public final static String ELOC = "INTERNET";
-	/** temporary call numbers (in process, on order ..) should start with this prefix */
-	public final static String TMP_CALLNUM_PREFIX = "XX";
+  /** call number for SUL online items */
+  public final static String ECALLNUM = "INTERNET RESOURCE";
+  /** location code for online items */
+  public final static String ELOC = "INTERNET";
+  /** temporary call numbers (in process, on order ..) should start with this prefix */
+  public final static String TMP_CALLNUM_PREFIX = "XX";
 
-	/* immutable instance variables */
-	private final String recId;
-	private final String barcode;
-	private final String library;
-	private final String itemType;
-	private final String publicNote;
-	private final boolean shouldBeSkipped;
-	private final boolean hasGovDocLoc;
-	private final boolean isOnline;
-	private final boolean hasShelbyLoc;
-	private final boolean hasBizShelbyLoc;
-	private final boolean hasLaneLoc;
-	private final boolean hasArtLockedLoc;
+  /* immutable instance variables */
+  private final String recId;
+  private final String barcode;
+  private final String library;
+  private final String itemType;
+  private final String publicNote;
+  private final boolean shouldBeSkipped;
+  private final boolean hasGovDocLoc;
+  private final boolean isOnline;
+  private final boolean hasShelbyLoc;
+  private final boolean hasBizShelbyLoc;
+  private final boolean hasLaneLoc;
+  private final boolean hasArtLockedLoc;
 
-	/* normal instance variables */
-	private CallNumberType callnumType;
-	private String homeLoc;
-	private String currLoc;
-	private String normCallnum;
-	private boolean isOnOrder = false;
-	private boolean isInProcess = false;
-	private boolean hasIgnoredCallnum = false;
-	private boolean hasBadLcLaneCallnum = false;
-	private boolean isMissingLost = false;
-	private boolean hasSeparateBrowseCallnum = false;
-	/** call number with volume suffix lopped off the end.  Used to remove
-	 * noise in search results and in browsing */
-	private String loppedCallnum = null;
-	/** set when there is a callnumber for browsing different from that in the 999 */
-	private String browseCallnum = null;
+  /* normal instance variables */
+  private CallNumberType callnumType;
+  private String homeLoc;
+  private String currLoc;
+  private String normCallnum;
+  private boolean isOnOrder = false;
+  private boolean isInProcess = false;
+  private boolean hasIgnoredCallnum = false;
+  private boolean hasBadLcLaneCallnum = false;
+  private boolean isMissingLost = false;
+  private boolean hasSeparateBrowseCallnum = false;
+  /** call number with volume suffix lopped off the end.  Used to remove
+   * noise in search results and in browsing */
+  private String loppedCallnum = null;
+  /** set when there is a callnumber for browsing different from that in the 999 */
+  private String browseCallnum = null;
 
-	/** sortable version of lopped call number */
-	private String loppedShelfkey = null;
+  /** sortable version of lopped call number */
+  private String loppedShelfkey = null;
 
-	/** reverse sorted version of loppedShelfkey - the last call number shall
-	 * be first, etc. */
-	private String reverseLoppedShelfkey = null;
+  /** reverse sorted version of loppedShelfkey - the last call number shall
+   * be first, etc. */
+  private String reverseLoppedShelfkey = null;
 
-	/** sortable full call number, where, for serials, any volume suffix will sort
-	 * in descending order.  Non-serial volumes will sort in ascending order. */
-	private String callnumVolSort = null;
-
-
-
-	/**
-	 * initialize object from 999 DataField, which has the following subfields
-	 * <ul>
-	 *   <li>a - call num</li>
-	 *   <li>i - barcode</li>
-	 *   <li>k - current location</li>
-	 *   <li>l - home location</li>
-	 *   <li>m - library code</li>
-	 *   <li>o - public note</li>
-	 *   <li>t - item type</li>
-	 *   <li>w - call num type</li>
-	 *  </ul>
-	 */
-	public Item(DataField f999, String recId) {
-		// set all the immutable variables
-		this.recId = recId;
-		barcode = MarcUtils.getSubfieldTrimmed(f999, 'i');
-		currLoc = MarcUtils.getSubfieldTrimmed(f999, 'k');
-		homeLoc = MarcUtils.getSubfieldTrimmed(f999, 'l');
-		library = MarcUtils.getSubfieldTrimmed(f999, 'm');
-		publicNote = MarcUtils.getSubfieldTrimmed(f999, 'o');
-		itemType = MarcUtils.getSubfieldTrimmed(f999, 't');
-		String scheme = MarcUtils.getSubfieldTrimmed(f999, 'w');
-		String rawCallnum = MarcUtils.getSubfieldTrimmed(f999, 'a');
-
-		if (StanfordIndexer.SKIPPED_LOCS.contains(currLoc)
-					|| StanfordIndexer.SKIPPED_LOCS.contains(homeLoc)
-					|| itemType.equals("EDI-REMOVE")
-					// SW-849 skip PHYSICS items that aren't location PHYSTEMP
-					|| (library.equals("PHYSICS") && (!homeLoc.equals("PHYSTEMP") && !currLoc.equals("PHYSTEMP")))
-          || StanfordIndexer.CLOSED_LIBS.contains(library))
-			shouldBeSkipped = true;
-		else
-			shouldBeSkipped = false;
-
-		if (StanfordIndexer.GOV_DOC_LOCS.contains(currLoc)
-				|| StanfordIndexer.GOV_DOC_LOCS.contains(homeLoc) )
-			hasGovDocLoc = true;
-		else
-			hasGovDocLoc = false;
-
-		if (StanfordIndexer.MISSING_LOCS.contains(currLoc)
-				|| StanfordIndexer.MISSING_LOCS.contains(homeLoc) )
-			isMissingLost = true;
-		else
-			isMissingLost = false;
-
-		if (library.equals("BUSINESS")
-				&& (StanfordIndexer.BIZ_SHELBY_LOCS.contains(currLoc)
-						|| StanfordIndexer.BIZ_SHELBY_LOCS.contains(homeLoc) ) )
-			hasBizShelbyLoc = true;
-		else
-			hasBizShelbyLoc = false;
-
-		if (library.equals("LANE-MED"))
-			hasLaneLoc = true;
-		else
-			hasLaneLoc = false;
-
-		if (StanfordIndexer.ART_LOCKED_LOCS.contains(homeLoc))
-			hasArtLockedLoc = true;
-		else
-			hasArtLockedLoc = false;
-
-		if (StanfordIndexer.SHELBY_LOCS.contains(currLoc)
-				|| StanfordIndexer.SHELBY_LOCS.contains(homeLoc) )
-			hasShelbyLoc = true;
-		else if (hasBizShelbyLoc)
-			hasShelbyLoc = true;
-		else
-			hasShelbyLoc = false;
-
-		if (StanfordIndexer.SKIPPED_CALLNUMS.contains(rawCallnum)
-				|| rawCallnum.startsWith(ECALLNUM)
-				|| (rawCallnum.startsWith(TMP_CALLNUM_PREFIX) && !(library.equals("HV-ARCHIVE"))))
-			hasIgnoredCallnum = true;
-		else
-			hasIgnoredCallnum = false;
-
-		assignCallnumType(scheme);
-		if (!hasIgnoredCallnum) {
-			if (callnumType == CallNumberType.LC || callnumType == CallNumberType.DEWEY)
-				normCallnum = CallNumUtils.normalizeCallnum(rawCallnum);
-			else
-				normCallnum = rawCallnum.trim();
-			validateCallnum(recId);
-		}
-		else
-			normCallnum = rawCallnum.trim();
-
-		// isOnline is immutable so must be set here
-		if (StanfordIndexer.ONLINE_LOCS.contains(currLoc)
-				|| StanfordIndexer.ONLINE_LOCS.contains(homeLoc) //) {
-				|| normCallnum.startsWith(ECALLNUM) ) {
-			isOnline = true;
-		}
-		else
-			isOnline = false;
-
-		dealWithXXCallnums(recId);
-	}
-
-	public String getBarcode() {
-		return barcode;
-	}
-
-	public String getLibrary() {
-		return library;
-	}
-
-	public String getHomeLoc() {
-		return homeLoc;
-	}
-
-	public String getCurrLoc() {
-		return currLoc;
-	}
-
-	public String getType() {
-		return itemType;
-	}
-
-	public String getCallnum() {
-		return normCallnum;
-	}
-
-	public String getPublicNote() {
-		if (this.publicNote.toUpperCase().startsWith(".PUBLIC."))
-			return publicNote;
-		else
-			return "";
-	}
-
-	public CallNumberType getCallnumType() {
-		return callnumType;
-	}
-
-	public void setCallnumType(CallNumberType callnumType) {
-		this.callnumType = callnumType;
-	}
-
-	/**
-	 * @return true if this item has a current or home location indicating it
-	 * should be skipped (e.g. "WITHDRAWN" or a shadowed location) or has
-	 * a type of "EDI-REMOVE")
-	 */
-	public boolean shouldBeSkipped() {
-		return shouldBeSkipped;
-	}
-
-	/**
-	 * @return true if item location indicating it is missing or lost
-	 */
-	public boolean isMissingOrLost() {
-		return isMissingLost;
-	}
-
-	/**
-	 * @return true if item has a government doc location
-	 */
-	public boolean hasGovDocLoc() {
-		return hasGovDocLoc;
-	}
-
-	/**
-	 * return true if item has a callnumber or location code indicating it is online
-	 */
-	public boolean isOnline() {
-		if (normCallnum.startsWith(ECALLNUM) || homeLoc.equals(ELOC) || currLoc.equals(ELOC))
-			return true;
-		else
-			return isOnline;
-	}
-
-	/**
-	 * @return true if item is on order
-	 */
-	public boolean isOnOrder() {
-		return isOnOrder;
-	}
-
-	/**
-	 * @return true if item is in process
-	 */
-	public boolean isInProcess() {
-		return isInProcess;
-	}
-
-	/**
-	 * return true if item has a shelby location (current or home)
-	 */
-	public boolean hasShelbyLoc() {
-		return hasShelbyLoc;
-	}
-
-	/**
-	 * return true if item has a business library only shelby location (current or home)
-	 */
-	public boolean hasBizShelbyLoc() {
-		return hasBizShelbyLoc;
-	}
-
-	/**
-	 * @return true if item has a Lane Medical location
-	 */
-	public boolean hasLaneLoc() {
-		return hasLaneLoc;
-	}
-
-	/**
-	 * @return true if item has a value for the location facet
-	 */
-	public boolean hasArtLockedLoc() {
-		return hasArtLockedLoc;
-	}
-
-	/**
-	 * @return true if call number is to be ignored in some contexts
-	 *  (e.g. "NO CALL NUMBER" or "XX(blah)")
-	 */
-	public boolean hasIgnoredCallnum() {
-		return hasIgnoredCallnum;
-	}
-
-	/**
-	 * @return true if call number is Lane (Law) invalid LC callnum
-	 */
-	public boolean hasBadLcLaneCallnum() {
-		return hasBadLcLaneCallnum;
-	}
-
-	/**
-	 * @return true if item has a call number from the bib fields
-	 */
-	public boolean hasSeparateBrowseCallnum() {
-		return hasSeparateBrowseCallnum;
-	}
-
-	/**
-	 * return the call number for browsing - it could be a call number provided
-	 *  outside of the item record.   This method will NOT set the lopped call
-	 *  number if the raw call number is from the item record and no
-	 *  lopped call number has been set yet.
-	 */
-	public String getBrowseCallnum() {
-		if (hasSeparateBrowseCallnum)
-			return browseCallnum;
-		else
-			return loppedCallnum;
-	}
-
-	/**
-	 * return the call number for browsing - it could be a call number provided
-	 *  outside of the item record (e.g. in 082).  This method will SET the
-	 *  lopped call number if the raw call number is from the item record and no
-	 *  lopped call number has been set yet.
-	 */
-	public String getBrowseCallnum(boolean isSerial) {
-		if (hasSeparateBrowseCallnum)
-			return browseCallnum;
-		else
-			return getLoppedCallnum(isSerial);
-	}
-
-	/**
-	 * for resources that have items without browsable call numbers
-	 * (SUL INTERNET RESOURCE), we look for a call number in the bib record
-	 * fields (050, 090, 086 ...) for browse nearby and for call number facets.
-	 * If one is found, this method is used.
-	 */
-	public void setBrowseCallnum(String callnum) {
-		hasSeparateBrowseCallnum = true;
-		if (callnumType == CallNumberType.LC || callnumType == CallNumberType.DEWEY)
-			browseCallnum = CallNumUtils.normalizeCallnum(callnum);
-		else
-			browseCallnum = callnum.trim();
-	}
-
-	/**
-	 * get the lopped call number (any volume suffix is lopped off the end.)
-	 * This will remove noise in search results and in browsing.
-	 * @param isSerial - true if item is for a serial.  Used to determine if
-	 *   year suffix should be lopped in addition to regular volume lopping.
-	 */
-	public String getLoppedCallnum(boolean isSerial) {
-		if (loppedCallnum == null)
-			setLoppedCallnum(isSerial);
-		return loppedCallnum;
-	}
-
-	/**
-	 * sets the private field loppedCallnum to contain the call number without
-	 *  any volume suffix information.
-	 * @param isSerial - true if item is for a serial.  Used to determine if
-	 *   year suffix should be lopped in addition to regular volume lopping.
-	 */
-	private void setLoppedCallnum(boolean isSerial) {
-		loppedCallnum = edu.stanford.CallNumUtils.getLoppedCallnum(normCallnum, callnumType, isSerial);
-		if (!loppedCallnum.endsWith(" ...") && !loppedCallnum.equals(normCallnum))
-			loppedCallnum = loppedCallnum + " ...";
-	}
-
-	/**
-	 * sets the private field loppedCallnum to the passed value.  Used when
-	 *  lopping must be dictated elsewhere.
-	 */
-	void setLoppedCallnum(String loppedCallnum) {
-		this.loppedCallnum = loppedCallnum;
-		if (!loppedCallnum.endsWith(" ...") && !loppedCallnum.equals(normCallnum))
-			this.loppedCallnum = loppedCallnum + " ...";
-	}
+  /** sortable full call number, where, for serials, any volume suffix will sort
+   * in descending order.  Non-serial volumes will sort in ascending order. */
+  private String callnumVolSort = null;
 
 
-	/**
-	 * get the sortable version of the lopped call number.
-	 * @param isSerial - true if item is for a serial.
-	 */
-	public String getShelfkey(boolean isSerial) {
-		if (loppedShelfkey == null)
-			setShelfkey(isSerial);
-		return loppedShelfkey;
-	}
 
-	/**
-	 * sets the private field loppedShelfkey (and loppedCallnum if it's not
-	 *  already set).  loppedShelfkey will contain the sortable version of the
-	 *  lopped call number
-	 * @param isSerial - true if item is for a serial.
-	 */
-	private void setShelfkey(boolean isSerial) {
-		if (loppedShelfkey == null) {
-			String skeyCallnum = getBrowseCallnum(isSerial);
-			if (skeyCallnum != null && skeyCallnum.length() > 0
-				&& !StanfordIndexer.SKIPPED_CALLNUMS.contains(skeyCallnum)
-				&& !skeyCallnum.startsWith(ECALLNUM)
-				&& (!skeyCallnum.startsWith(TMP_CALLNUM_PREFIX)
-				|| (skeyCallnum.startsWith(TMP_CALLNUM_PREFIX) && library.equals("HV-ARCHIVE")) ))
-				loppedShelfkey = edu.stanford.CallNumUtils.getShelfKey(skeyCallnum, callnumType, recId);
-		}
-	}
+  /**
+   * initialize object from 999 DataField, which has the following subfields
+   * <ul>
+   *   <li>a - call num</li>
+   *   <li>i - barcode</li>
+   *   <li>k - current location</li>
+   *   <li>l - home location</li>
+   *   <li>m - library code</li>
+   *   <li>o - public note</li>
+   *   <li>t - item type</li>
+   *   <li>w - call num type</li>
+   *  </ul>
+   */
+  public Item(DataField f999, String recId) {
+    // set all the immutable variables
+    this.recId = recId;
+    barcode = MarcUtils.getSubfieldTrimmed(f999, 'i');
+    currLoc = MarcUtils.getSubfieldTrimmed(f999, 'k');
+    homeLoc = MarcUtils.getSubfieldTrimmed(f999, 'l');
+    library = MarcUtils.getSubfieldTrimmed(f999, 'm');
+    publicNote = MarcUtils.getSubfieldTrimmed(f999, 'o');
+    itemType = MarcUtils.getSubfieldTrimmed(f999, 't');
+    String scheme = MarcUtils.getSubfieldTrimmed(f999, 'w');
+    String rawCallnum = MarcUtils.getSubfieldTrimmed(f999, 'a');
 
-	/**
-	 * get the reverse sortable version of the lopped call number.
-	 * @param isSerial - true if item is for a serial.
-	 */
-	public String getReverseShelfkey(boolean isSerial) {
-		if (reverseLoppedShelfkey == null)
-			setReverseShelfkey(isSerial);
-		return reverseLoppedShelfkey;
-	}
+    if (StanfordIndexer.SKIPPED_LOCS.contains(currLoc)
+          || StanfordIndexer.SKIPPED_LOCS.contains(homeLoc)
+          || itemType.equals("EDI-REMOVE")
+          // SW-849 skip PHYSICS items that aren't location PHYSTEMP
+          || (library.equals("PHYSICS") && (!homeLoc.equals("PHYSTEMP") && !currLoc.equals("PHYSTEMP"))))
+      shouldBeSkipped = true;
+    else if (StanfordIndexer.CLOSED_LIBS.contains(library) && (StanfordIndexer.RESV_LOCS.contains(currLoc)))
+      shouldBeSkipped = false;
+    else if (StanfordIndexer.CLOSED_LIBS.contains(library))
+      shouldBeSkipped = true;
+    else
+      shouldBeSkipped = false;
 
-	/**
-	 * sets the private field reverseLoppedShelfkey (and loppedShelfkey and
-	 *  loppedCallnum if they're not already set).  reverseLoppedShelfkey will
-	 *  contain the reverse sortable version of the lopped call number.
-	 * @param isSerial - true if item is for a serial.
-	 */
-	private void setReverseShelfkey(boolean isSerial) {
-		if (loppedShelfkey == null)
-			setShelfkey(isSerial);
-		if (loppedShelfkey != null && loppedShelfkey.length() > 0)
-			reverseLoppedShelfkey = CallNumUtils.getReverseShelfKey(loppedShelfkey);
-	}
+    if (StanfordIndexer.GOV_DOC_LOCS.contains(currLoc)
+        || StanfordIndexer.GOV_DOC_LOCS.contains(homeLoc) )
+      hasGovDocLoc = true;
+    else
+      hasGovDocLoc = false;
+
+    if (StanfordIndexer.MISSING_LOCS.contains(currLoc)
+        || StanfordIndexer.MISSING_LOCS.contains(homeLoc) )
+      isMissingLost = true;
+    else
+      isMissingLost = false;
+
+    if (library.equals("BUSINESS")
+        && (StanfordIndexer.BIZ_SHELBY_LOCS.contains(currLoc)
+            || StanfordIndexer.BIZ_SHELBY_LOCS.contains(homeLoc) ) )
+      hasBizShelbyLoc = true;
+    else
+      hasBizShelbyLoc = false;
+
+    if (library.equals("LANE-MED"))
+      hasLaneLoc = true;
+    else
+      hasLaneLoc = false;
+
+    if (StanfordIndexer.ART_LOCKED_LOCS.contains(homeLoc))
+      hasArtLockedLoc = true;
+    else
+      hasArtLockedLoc = false;
+
+    if (StanfordIndexer.SHELBY_LOCS.contains(currLoc)
+        || StanfordIndexer.SHELBY_LOCS.contains(homeLoc) )
+      hasShelbyLoc = true;
+    else if (hasBizShelbyLoc)
+      hasShelbyLoc = true;
+    else
+      hasShelbyLoc = false;
+
+    if (StanfordIndexer.SKIPPED_CALLNUMS.contains(rawCallnum)
+        || rawCallnum.startsWith(ECALLNUM)
+        || (rawCallnum.startsWith(TMP_CALLNUM_PREFIX) && !(library.equals("HV-ARCHIVE"))))
+      hasIgnoredCallnum = true;
+    else
+      hasIgnoredCallnum = false;
+
+    assignCallnumType(scheme);
+    if (!hasIgnoredCallnum) {
+      if (callnumType == CallNumberType.LC || callnumType == CallNumberType.DEWEY)
+        normCallnum = CallNumUtils.normalizeCallnum(rawCallnum);
+      else
+        normCallnum = rawCallnum.trim();
+      validateCallnum(recId);
+    }
+    else
+      normCallnum = rawCallnum.trim();
+
+    // isOnline is immutable so must be set here
+    if (StanfordIndexer.ONLINE_LOCS.contains(currLoc)
+        || StanfordIndexer.ONLINE_LOCS.contains(homeLoc) //) {
+        || normCallnum.startsWith(ECALLNUM) ) {
+      isOnline = true;
+    }
+    else
+      isOnline = false;
+
+    dealWithXXCallnums(recId);
+  }
+
+  public String getBarcode() {
+    return barcode;
+  }
+
+  public String getLibrary() {
+    return library;
+  }
+
+  public String getHomeLoc() {
+    return homeLoc;
+  }
+
+  public String getCurrLoc() {
+    return currLoc;
+  }
+
+  public String getType() {
+    return itemType;
+  }
+
+  public String getCallnum() {
+    return normCallnum;
+  }
+
+  public String getPublicNote() {
+    if (this.publicNote.toUpperCase().startsWith(".PUBLIC."))
+      return publicNote;
+    else
+      return "";
+  }
+
+  public CallNumberType getCallnumType() {
+    return callnumType;
+  }
+
+  public void setCallnumType(CallNumberType callnumType) {
+    this.callnumType = callnumType;
+  }
+
+  /**
+   * @return true if this item has a current or home location indicating it
+   * should be skipped (e.g. "WITHDRAWN" or a shadowed location) or has
+   * a type of "EDI-REMOVE")
+   */
+  public boolean shouldBeSkipped() {
+    return shouldBeSkipped;
+  }
+
+  /**
+   * @return true if item location indicating it is missing or lost
+   */
+  public boolean isMissingOrLost() {
+    return isMissingLost;
+  }
+
+  /**
+   * @return true if item has a government doc location
+   */
+  public boolean hasGovDocLoc() {
+    return hasGovDocLoc;
+  }
+
+  /**
+   * return true if item has a callnumber or location code indicating it is online
+   */
+  public boolean isOnline() {
+    if (normCallnum.startsWith(ECALLNUM) || homeLoc.equals(ELOC) || currLoc.equals(ELOC))
+      return true;
+    else
+      return isOnline;
+  }
+
+  /**
+   * @return true if item is on order
+   */
+  public boolean isOnOrder() {
+    return isOnOrder;
+  }
+
+  /**
+   * @return true if item is in process
+   */
+  public boolean isInProcess() {
+    return isInProcess;
+  }
+
+  /**
+   * return true if item has a shelby location (current or home)
+   */
+  public boolean hasShelbyLoc() {
+    return hasShelbyLoc;
+  }
+
+  /**
+   * return true if item has a business library only shelby location (current or home)
+   */
+  public boolean hasBizShelbyLoc() {
+    return hasBizShelbyLoc;
+  }
+
+  /**
+   * @return true if item has a Lane Medical location
+   */
+  public boolean hasLaneLoc() {
+    return hasLaneLoc;
+  }
+
+  /**
+   * @return true if item has a value for the location facet
+   */
+  public boolean hasArtLockedLoc() {
+    return hasArtLockedLoc;
+  }
+
+  /**
+   * @return true if call number is to be ignored in some contexts
+   *  (e.g. "NO CALL NUMBER" or "XX(blah)")
+   */
+  public boolean hasIgnoredCallnum() {
+    return hasIgnoredCallnum;
+  }
+
+  /**
+   * @return true if call number is Lane (Law) invalid LC callnum
+   */
+  public boolean hasBadLcLaneCallnum() {
+    return hasBadLcLaneCallnum;
+  }
+
+  /**
+   * @return true if item has a call number from the bib fields
+   */
+  public boolean hasSeparateBrowseCallnum() {
+    return hasSeparateBrowseCallnum;
+  }
+
+  /**
+   * return the call number for browsing - it could be a call number provided
+   *  outside of the item record.   This method will NOT set the lopped call
+   *  number if the raw call number is from the item record and no
+   *  lopped call number has been set yet.
+   */
+  public String getBrowseCallnum() {
+    if (hasSeparateBrowseCallnum)
+      return browseCallnum;
+    else
+      return loppedCallnum;
+  }
+
+  /**
+   * return the call number for browsing - it could be a call number provided
+   *  outside of the item record (e.g. in 082).  This method will SET the
+   *  lopped call number if the raw call number is from the item record and no
+   *  lopped call number has been set yet.
+   */
+  public String getBrowseCallnum(boolean isSerial) {
+    if (hasSeparateBrowseCallnum)
+      return browseCallnum;
+    else
+      return getLoppedCallnum(isSerial);
+  }
+
+  /**
+   * for resources that have items without browsable call numbers
+   * (SUL INTERNET RESOURCE), we look for a call number in the bib record
+   * fields (050, 090, 086 ...) for browse nearby and for call number facets.
+   * If one is found, this method is used.
+   */
+  public void setBrowseCallnum(String callnum) {
+    hasSeparateBrowseCallnum = true;
+    if (callnumType == CallNumberType.LC || callnumType == CallNumberType.DEWEY)
+      browseCallnum = CallNumUtils.normalizeCallnum(callnum);
+    else
+      browseCallnum = callnum.trim();
+  }
+
+  /**
+   * get the lopped call number (any volume suffix is lopped off the end.)
+   * This will remove noise in search results and in browsing.
+   * @param isSerial - true if item is for a serial.  Used to determine if
+   *   year suffix should be lopped in addition to regular volume lopping.
+   */
+  public String getLoppedCallnum(boolean isSerial) {
+    if (loppedCallnum == null)
+      setLoppedCallnum(isSerial);
+    return loppedCallnum;
+  }
+
+  /**
+   * sets the private field loppedCallnum to contain the call number without
+   *  any volume suffix information.
+   * @param isSerial - true if item is for a serial.  Used to determine if
+   *   year suffix should be lopped in addition to regular volume lopping.
+   */
+  private void setLoppedCallnum(boolean isSerial) {
+    loppedCallnum = edu.stanford.CallNumUtils.getLoppedCallnum(normCallnum, callnumType, isSerial);
+    if (!loppedCallnum.endsWith(" ...") && !loppedCallnum.equals(normCallnum))
+      loppedCallnum = loppedCallnum + " ...";
+  }
+
+  /**
+   * sets the private field loppedCallnum to the passed value.  Used when
+   *  lopping must be dictated elsewhere.
+   */
+  void setLoppedCallnum(String loppedCallnum) {
+    this.loppedCallnum = loppedCallnum;
+    if (!loppedCallnum.endsWith(" ...") && !loppedCallnum.equals(normCallnum))
+      this.loppedCallnum = loppedCallnum + " ...";
+  }
 
 
-	/**
-	 * get the sortable full call number, where, for serials, any volume suffix
-	 * will sort in descending order.  Non-serial volumes will sort in ascending
-	 * order.
-	 * @param isSerial - true if item is for a serial.
-	 */
-	public String getCallnumVolSort(boolean isSerial) {
-		if (callnumVolSort == null)
-			setCallnumVolSort(isSerial);
-		return callnumVolSort;
-	}
+  /**
+   * get the sortable version of the lopped call number.
+   * @param isSerial - true if item is for a serial.
+   */
+  public String getShelfkey(boolean isSerial) {
+    if (loppedShelfkey == null)
+      setShelfkey(isSerial);
+    return loppedShelfkey;
+  }
 
-	/**
-	 * sets the private field callnumVolSort (and loppedShelfkey and
-	 * loppedCallnum if they're not already set.)  callnumVolSort will contain
-	 * the sortable full call number, where, for serials, any volume suffix
-	 * will sort in descending order.
-	 * @param isSerial - true if item is for a serial.
-	 */
-	private void setCallnumVolSort(boolean isSerial) {
-		if (loppedShelfkey == null)
-			// note:  setting loppedShelfkey will also set loppedCallnum
-			loppedShelfkey = getShelfkey(isSerial);
-		if (loppedShelfkey != null && loppedShelfkey.length() > 0)
-			callnumVolSort = edu.stanford.CallNumUtils.getVolumeSortCallnum(
-				normCallnum, loppedCallnum, loppedShelfkey, callnumType, isSerial, recId);
-	}
+  /**
+   * sets the private field loppedShelfkey (and loppedCallnum if it's not
+   *  already set).  loppedShelfkey will contain the sortable version of the
+   *  lopped call number
+   * @param isSerial - true if item is for a serial.
+   */
+  private void setShelfkey(boolean isSerial) {
+    if (loppedShelfkey == null) {
+      String skeyCallnum = getBrowseCallnum(isSerial);
+      if (skeyCallnum != null && skeyCallnum.length() > 0
+        && !StanfordIndexer.SKIPPED_CALLNUMS.contains(skeyCallnum)
+        && !skeyCallnum.startsWith(ECALLNUM)
+        && (!skeyCallnum.startsWith(TMP_CALLNUM_PREFIX)
+        || (skeyCallnum.startsWith(TMP_CALLNUM_PREFIX) && library.equals("HV-ARCHIVE")) ))
+        loppedShelfkey = edu.stanford.CallNumUtils.getShelfKey(skeyCallnum, callnumType, recId);
+    }
+  }
+
+  /**
+   * get the reverse sortable version of the lopped call number.
+   * @param isSerial - true if item is for a serial.
+   */
+  public String getReverseShelfkey(boolean isSerial) {
+    if (reverseLoppedShelfkey == null)
+      setReverseShelfkey(isSerial);
+    return reverseLoppedShelfkey;
+  }
+
+  /**
+   * sets the private field reverseLoppedShelfkey (and loppedShelfkey and
+   *  loppedCallnum if they're not already set).  reverseLoppedShelfkey will
+   *  contain the reverse sortable version of the lopped call number.
+   * @param isSerial - true if item is for a serial.
+   */
+  private void setReverseShelfkey(boolean isSerial) {
+    if (loppedShelfkey == null)
+      setShelfkey(isSerial);
+    if (loppedShelfkey != null && loppedShelfkey.length() > 0)
+      reverseLoppedShelfkey = CallNumUtils.getReverseShelfKey(loppedShelfkey);
+  }
 
 
-	/** call numbers must start with a letter or digit */
+  /**
+   * get the sortable full call number, where, for serials, any volume suffix
+   * will sort in descending order.  Non-serial volumes will sort in ascending
+   * order.
+   * @param isSerial - true if item is for a serial.
+   */
+  public String getCallnumVolSort(boolean isSerial) {
+    if (callnumVolSort == null)
+      setCallnumVolSort(isSerial);
+    return callnumVolSort;
+  }
+
+  /**
+   * sets the private field callnumVolSort (and loppedShelfkey and
+   * loppedCallnum if they're not already set.)  callnumVolSort will contain
+   * the sortable full call number, where, for serials, any volume suffix
+   * will sort in descending order.
+   * @param isSerial - true if item is for a serial.
+   */
+  private void setCallnumVolSort(boolean isSerial) {
+    if (loppedShelfkey == null)
+      // note:  setting loppedShelfkey will also set loppedCallnum
+      loppedShelfkey = getShelfkey(isSerial);
+    if (loppedShelfkey != null && loppedShelfkey.length() > 0)
+      callnumVolSort = edu.stanford.CallNumUtils.getVolumeSortCallnum(
+        normCallnum, loppedCallnum, loppedShelfkey, callnumType, isSerial, recId);
+  }
+
+
+  /** call numbers must start with a letter or digit */
     private static final Pattern STRANGE_CALLNUM_START_CHARS = Pattern.compile("^\\p{Alnum}");
 
-	/**
-	 * output an error message if the call number is supposed to be LC or DEWEY
-	 *  but is invalid
-	 * @param recId the id of the record, used in error message
-	 */
-	private void validateCallnum(String recId) {
-		if (callnumType == CallNumberType.LC
-				&& !CallNumUtils.isValidLC(normCallnum)) {
-			if (!library.equals("LANE-MED"))
-				System.err.println("record " + recId + " has invalid LC callnumber: " + normCallnum);
-			adjustLCCallnumType(recId);
-		}
-		if (callnumType == CallNumberType.DEWEY
-				&& !CallNumUtils.isValidDeweyWithCutter(normCallnum)) {
-			System.err.println("record " + recId + " has invalid DEWEY callnumber: " + normCallnum);
-			callnumType = CallNumberType.OTHER;
-		}
-		else if (STRANGE_CALLNUM_START_CHARS.matcher(normCallnum).matches())
-			System.err.println("record " + recId + " has strange callnumber: " + normCallnum);
-	}
+  /**
+   * output an error message if the call number is supposed to be LC or DEWEY
+   *  but is invalid
+   * @param recId the id of the record, used in error message
+   */
+  private void validateCallnum(String recId) {
+    if (callnumType == CallNumberType.LC
+        && !CallNumUtils.isValidLC(normCallnum)) {
+      if (!library.equals("LANE-MED"))
+        System.err.println("record " + recId + " has invalid LC callnumber: " + normCallnum);
+      adjustLCCallnumType(recId);
+    }
+    if (callnumType == CallNumberType.DEWEY
+        && !CallNumUtils.isValidDeweyWithCutter(normCallnum)) {
+      System.err.println("record " + recId + " has invalid DEWEY callnumber: " + normCallnum);
+      callnumType = CallNumberType.OTHER;
+    }
+    else if (STRANGE_CALLNUM_START_CHARS.matcher(normCallnum).matches())
+      System.err.println("record " + recId + " has strange callnumber: " + normCallnum);
+  }
 
-	/**
-	 * LC is default call number scheme assigned;  change it if assigned
-	 *   incorrectly to a Dewey or ALPHANUM call number.  Called after
-	 *   printMsgIfInvalidCallnum has already found invalid LC call number
-	 */
-	private void adjustLCCallnumType(String id) {
-		if (callnumType == CallNumberType.LC) {
-			if (CallNumUtils.isValidDeweyWithCutter(normCallnum))
-				callnumType = CallNumberType.DEWEY;
-			else
-			{
+  /**
+   * LC is default call number scheme assigned;  change it if assigned
+   *   incorrectly to a Dewey or ALPHANUM call number.  Called after
+   *   printMsgIfInvalidCallnum has already found invalid LC call number
+   */
+  private void adjustLCCallnumType(String id) {
+    if (callnumType == CallNumberType.LC) {
+      if (CallNumUtils.isValidDeweyWithCutter(normCallnum))
+        callnumType = CallNumberType.DEWEY;
+      else
+      {
 //  FIXME:   this is no good if the call number is SUDOC but mislabeled LC ...
-				callnumType = CallNumberType.OTHER;
-				if (library.equals("LANE-MED"))
-					hasBadLcLaneCallnum = true;
-			}
-		}
-	}
+        callnumType = CallNumberType.OTHER;
+        if (library.equals("LANE-MED"))
+          hasBadLcLaneCallnum = true;
+      }
+    }
+  }
 
-	/**
-	 * if item has XX call number
-	 *   if home location or current location is INPROCESS or ON-ORDER, do
-	 *     the obvious thing
-	 *   if no home or current location, item is on order.
-	 *   o.w. if the current location isn't shadowed, it is an error;
-	 *     print an error message and fake "ON-ORDER"
-	 * @param recId - for error message
-	 */
-	private void dealWithXXCallnums(String recId) {
-		if (normCallnum.startsWith(TMP_CALLNUM_PREFIX))
-		{
-			if (currLoc.equals("ON-ORDER"))
-				isOnOrder = true;
-			else if (currLoc.equals("INPROCESS"))
-				isInProcess = true;
-			else if (shouldBeSkipped || currLoc.equals("LAC") || homeLoc.equals("LAC") || library.equals("HV-ARCHIVE"))
-				; // we're okay
-			else if (currLoc.length() > 0) {
-				System.err.println("record " + recId + " has XX callnumber but current location is not ON-ORDER or INPROCESS or shadowy");
-				if (homeLoc.equals("ON-ORDER") || homeLoc.equals("INPROCESS")) {
-					currLoc = homeLoc;
-					homeLoc = "";
-					if (currLoc.equals("ON-ORDER"))
-						isOnOrder = true;
-					else
-						isInProcess = true;
-				}
-				else {
-					currLoc = "ON-ORDER";
-					isOnOrder = true;
-				}
-			}
-		}
-	}
+  /**
+   * if item has XX call number
+   *   if home location or current location is INPROCESS or ON-ORDER, do
+   *     the obvious thing
+   *   if no home or current location, item is on order.
+   *   o.w. if the current location isn't shadowed, it is an error;
+   *     print an error message and fake "ON-ORDER"
+   * @param recId - for error message
+   */
+  private void dealWithXXCallnums(String recId) {
+    if (normCallnum.startsWith(TMP_CALLNUM_PREFIX))
+    {
+      if (currLoc.equals("ON-ORDER"))
+        isOnOrder = true;
+      else if (currLoc.equals("INPROCESS"))
+        isInProcess = true;
+      else if (shouldBeSkipped || currLoc.equals("LAC") || homeLoc.equals("LAC") || library.equals("HV-ARCHIVE"))
+        ; // we're okay
+      else if (currLoc.length() > 0) {
+        System.err.println("record " + recId + " has XX callnumber but current location is not ON-ORDER or INPROCESS or shadowy");
+        if (homeLoc.equals("ON-ORDER") || homeLoc.equals("INPROCESS")) {
+          currLoc = homeLoc;
+          homeLoc = "";
+          if (currLoc.equals("ON-ORDER"))
+            isOnOrder = true;
+          else
+            isInProcess = true;
+        }
+        else {
+          currLoc = "ON-ORDER";
+          isOnOrder = true;
+        }
+      }
+    }
+  }
 
-	/**
-	 * assign a value to callnumType based on scheme ...
-	 *   LCPER --> LC;  DEWEYPER --> DEWEY
-	 */
-	private void assignCallnumType(String scheme) {
-		if (scheme.startsWith("LC"))
-			callnumType = CallNumberType.LC;
-		else if (scheme.startsWith("DEWEY"))
-			callnumType = CallNumberType.DEWEY;
-		else if (scheme.equals("SUDOC"))
-			callnumType = CallNumberType.SUDOC;
-		else if (scheme.equals("ALPHANUM"))
-			callnumType = CallNumberType.ALPHANUM;
-		else
-			callnumType = CallNumberType.OTHER;
-	}
+  /**
+   * assign a value to callnumType based on scheme ...
+   *   LCPER --> LC;  DEWEYPER --> DEWEY
+   */
+  private void assignCallnumType(String scheme) {
+    if (scheme.startsWith("LC"))
+      callnumType = CallNumberType.LC;
+    else if (scheme.startsWith("DEWEY"))
+      callnumType = CallNumberType.DEWEY;
+    else if (scheme.equals("SUDOC"))
+      callnumType = CallNumberType.SUDOC;
+    else if (scheme.equals("ALPHANUM"))
+      callnumType = CallNumberType.ALPHANUM;
+    else
+      callnumType = CallNumberType.OTHER;
+  }
 
 }

--- a/stanford-sw/test/data/closedLibraries.xml
+++ b/stanford-sw/test/data/closedLibraries.xml
@@ -1,122 +1,145 @@
 <records xmlns='http://www.loc.gov/MARC21/slim'>
-	<!-- BIOLOGY only so do not index -->
-	<record>
-	    <leader>01801cam a2200361K  4500</leader>
-		<controlfield tag='001'>adoNotIndexBio</controlfield>
-	    <controlfield tag='008'>090724s2009    caua          100 0 eng d</controlfield>
-	    <datafield ind1='0' ind2='0' tag='245'>
-	    	<subfield code='a'>BIOLOGY only so do not index</subfield>
-	    </datafield>
-	    <datafield ind1='4' ind2='1' tag='856'>
-	        <subfield code='z'>Available to Stanford-affiliated users at:</subfield>
-	        <subfield code='u'>http://aspbooks.org/a/volumes/table_of_contents/?book_id=95</subfield>
-	    </datafield>
-	    <datafield ind1=' ' ind2=' ' tag='999'>
-	        <subfield code='a'>QB1 .A8133 V.402</subfield>
-	        <subfield code='w'>LC</subfield>
-	        <subfield code='c'>1</subfield>
-	        <subfield code='i'>36105210713652</subfield>
-	        <subfield code='l'>STACKS</subfield>
-	        <subfield code='m'>BIOLOGY</subfield>
-	        <subfield code='t'>STKS</subfield>
-	    </datafield>
-	</record>
-	<!-- CHEMCHMENG only so do not index -->
-	<record>
-		<leader>01801cam a2200361K  4500</leader>
-		<controlfield tag='001'>adoNotIndexChem</controlfield>
-		<controlfield tag='008'>090724s2009    caua          100 0 eng d</controlfield>
-		<datafield ind1='0' ind2='0' tag='245'>
-			<subfield code='a'>CHEMCHMENG only so do not index</subfield>
-		</datafield>
-		<datafield ind1='4' ind2='1' tag='856'>
-			<subfield code='z'>Available to Stanford-affiliated users at:</subfield>
-			<subfield code='u'>http://aspbooks.org/a/volumes/table_of_contents/?book_id=95</subfield>
-		</datafield>
-		<datafield ind1=' ' ind2=' ' tag='999'>
-			<subfield code='a'>QB1 .A8133 V.402</subfield>
-			<subfield code='w'>LC</subfield>
-			<subfield code='c'>1</subfield>
-			<subfield code='i'>36105210713652</subfield>
-			<subfield code='l'>STACKS</subfield>
-			<subfield code='m'>CHEMCHMENG</subfield>
-			<subfield code='t'>STKS</subfield>
-		</datafield>
-	</record>
-	<!-- MATH-CS only so do not index -->
-	<record>
-		<leader>01801cam a2200361K  4500</leader>
-		<controlfield tag='001'>adoNotIndexMath</controlfield>
-		<controlfield tag='008'>090724s2009    caua          100 0 eng d</controlfield>
-		<datafield ind1='0' ind2='0' tag='245'>
-			<subfield code='a'>MATH-CS only so do not index</subfield>
-		</datafield>
-		<datafield ind1='4' ind2='1' tag='856'>
-			<subfield code='z'>Available to Stanford-affiliated users at:</subfield>
-			<subfield code='u'>http://aspbooks.org/a/volumes/table_of_contents/?book_id=95</subfield>
-		</datafield>
-		<datafield ind1=' ' ind2=' ' tag='999'>
-			<subfield code='a'>QB1 .A8133 V.402</subfield>
-			<subfield code='w'>LC</subfield>
-			<subfield code='c'>1</subfield>
-			<subfield code='i'>36105210713652</subfield>
-			<subfield code='l'>STACKS</subfield>
-			<subfield code='m'>MATH-CS</subfield>
-			<subfield code='t'>STKS</subfield>
-		</datafield>
-	</record>
-	<!-- No Closed library -->
-	<record>
-		<leader>01801cam a2200361K  4500</leader>
-		<controlfield tag='001'>anoClosedLib</controlfield>
-		<controlfield tag='008'>090724s2009    caua          100 0 eng d</controlfield>
-		<datafield ind1='0' ind2='0' tag='245'>
-			<subfield code='a'>No Closed library</subfield>
-		</datafield>
-		<datafield ind1=' ' ind2=' ' tag='999'>
-			<subfield code='a'>QB1 .A8133 V.402</subfield>
-			<subfield code='w'>LC</subfield>
-			<subfield code='c'>1</subfield>
-			<subfield code='i'>36105210713652</subfield>
-			<subfield code='k'>STACKS</subfield>
-			<subfield code='m'>GREEN</subfield>
-			<subfield code='t'>STKS</subfield>
-		</datafield>
-	</record>
-	<!-- BIOLOGY and CHEMCHMENG in 999$m with other libraries/buildings so index but no building_facet for Biology or Chemistry/Chemical Eng-->
-	<record>
-	    <leader>01801cam a2200361K  4500</leader>
-		<controlfield tag='001'>aindexMultL</controlfield>
-	    <controlfield tag='008'>090724s2009    caua          100 0 eng d</controlfield>
-	    <datafield ind1='0' ind2='0' tag='245'>
-	    	<subfield code='a'>BIOLOGY and CHEMCHMENG in 999$m with other libraries/buildings so index but no building_facet for Biology or Chemistry/Chemical Eng</subfield>
-	    </datafield>
-	    <datafield ind1=' ' ind2=' ' tag='999'>
-	        <subfield code='a'>QB1 .A8133 V.402</subfield>
-	        <subfield code='w'>LC</subfield>
-	        <subfield code='c'>1</subfield>
-	        <subfield code='i'>36105210713652</subfield>
-	        <subfield code='k'>STACKS</subfield>
-	        <subfield code='m'>BIOLOGY</subfield>
-	        <subfield code='t'>STKS</subfield>
-	    </datafield>
-	        <datafield ind1=' ' ind2=' ' tag='999'>
-	        <subfield code='a'>QB1 .A8133 V.402</subfield>
-	        <subfield code='w'>LC</subfield>
-	        <subfield code='c'>1</subfield>
-	        <subfield code='i'>36105210713652</subfield>
-	        <subfield code='k'>STACKS</subfield>
-	        <subfield code='m'>CHEMCHMENG</subfield>
-	        <subfield code='t'>STKS</subfield>
-	    </datafield>
-	    <datafield ind1=' ' ind2=' ' tag='999'>
-	        <subfield code='a'>QB1 .A8133 V.402</subfield>
-	        <subfield code='w'>LC</subfield>
-	        <subfield code='c'>1</subfield>
-	        <subfield code='i'>36105210713652</subfield>
-	        <subfield code='l'>STACKS</subfield>
-	        <subfield code='m'>SCIENCE</subfield>
-	        <subfield code='t'>STKS</subfield>
-	    </datafield>
-	</record>
+  <!-- BIOLOGY only so do not index -->
+  <record>
+      <leader>01801cam a2200361K  4500</leader>
+    <controlfield tag='001'>adoNotIndexBio</controlfield>
+      <controlfield tag='008'>090724s2009    caua          100 0 eng d</controlfield>
+      <datafield ind1='0' ind2='0' tag='245'>
+        <subfield code='a'>BIOLOGY only so do not index</subfield>
+      </datafield>
+      <datafield ind1='4' ind2='1' tag='856'>
+          <subfield code='z'>Available to Stanford-affiliated users at:</subfield>
+          <subfield code='u'>http://aspbooks.org/a/volumes/table_of_contents/?book_id=95</subfield>
+      </datafield>
+      <datafield ind1=' ' ind2=' ' tag='999'>
+          <subfield code='a'>QB1 .A8133 V.402</subfield>
+          <subfield code='w'>LC</subfield>
+          <subfield code='c'>1</subfield>
+          <subfield code='i'>36105210713652</subfield>
+          <subfield code='l'>STACKS</subfield>
+          <subfield code='m'>BIOLOGY</subfield>
+          <subfield code='t'>STKS</subfield>
+      </datafield>
+  </record>
+  <!-- CHEMCHMENG only so do not index -->
+  <record>
+    <leader>01801cam a2200361K  4500</leader>
+    <controlfield tag='001'>adoNotIndexChem</controlfield>
+    <controlfield tag='008'>090724s2009    caua          100 0 eng d</controlfield>
+    <datafield ind1='0' ind2='0' tag='245'>
+      <subfield code='a'>CHEMCHMENG only so do not index</subfield>
+    </datafield>
+    <datafield ind1='4' ind2='1' tag='856'>
+      <subfield code='z'>Available to Stanford-affiliated users at:</subfield>
+      <subfield code='u'>http://aspbooks.org/a/volumes/table_of_contents/?book_id=95</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='999'>
+      <subfield code='a'>QB1 .A8133 V.402</subfield>
+      <subfield code='w'>LC</subfield>
+      <subfield code='c'>1</subfield>
+      <subfield code='i'>36105210713652</subfield>
+      <subfield code='l'>STACKS</subfield>
+      <subfield code='m'>CHEMCHMENG</subfield>
+      <subfield code='t'>STKS</subfield>
+    </datafield>
+  </record>
+  <!-- MATH-CS only so do not index -->
+  <record>
+    <leader>01801cam a2200361K  4500</leader>
+    <controlfield tag='001'>adoNotIndexMath</controlfield>
+    <controlfield tag='008'>090724s2009    caua          100 0 eng d</controlfield>
+    <datafield ind1='0' ind2='0' tag='245'>
+      <subfield code='a'>MATH-CS only so do not index</subfield>
+    </datafield>
+    <datafield ind1='4' ind2='1' tag='856'>
+      <subfield code='z'>Available to Stanford-affiliated users at:</subfield>
+      <subfield code='u'>http://aspbooks.org/a/volumes/table_of_contents/?book_id=95</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='999'>
+      <subfield code='a'>QB1 .A8133 V.402</subfield>
+      <subfield code='w'>LC</subfield>
+      <subfield code='c'>1</subfield>
+      <subfield code='i'>36105210713652</subfield>
+      <subfield code='l'>STACKS</subfield>
+      <subfield code='m'>MATH-CS</subfield>
+      <subfield code='t'>STKS</subfield>
+    </datafield>
+  </record>
+  <!-- MATH-CS only but on reserve in valid reserve location so should index -->
+  <record>
+    <leader>01801cam a2200361K  4500</leader>
+    <controlfield tag='001'>aIndexEngResv</controlfield>
+    <controlfield tag='008'>090724s2009    caua          100 0 eng d</controlfield>
+    <datafield ind1='0' ind2='0' tag='245'>
+      <subfield code='a'>MATH-CS only so do not index</subfield>
+    </datafield>
+    <datafield ind1='4' ind2='1' tag='856'>
+      <subfield code='z'>Available to Stanford-affiliated users at:</subfield>
+      <subfield code='u'>http://aspbooks.org/a/volumes/table_of_contents/?book_id=95</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='999'>
+      <subfield code='a'>QB1 .A8133 V.402</subfield>
+      <subfield code='w'>LC</subfield>
+      <subfield code='c'>1</subfield>
+      <subfield code='i'>36105210713652</subfield>
+      <subfield code='k'>ENG-RESV</subfield>
+      <subfield code='l'>STACKS</subfield>
+      <subfield code='m'>MATH-CS</subfield>
+      <subfield code='t'>STKS</subfield>
+    </datafield>
+  </record>
+  <!-- No Closed library -->
+  <record>
+    <leader>01801cam a2200361K  4500</leader>
+    <controlfield tag='001'>anoClosedLib</controlfield>
+    <controlfield tag='008'>090724s2009    caua          100 0 eng d</controlfield>
+    <datafield ind1='0' ind2='0' tag='245'>
+      <subfield code='a'>No Closed library</subfield>
+    </datafield>
+    <datafield ind1=' ' ind2=' ' tag='999'>
+      <subfield code='a'>QB1 .A8133 V.402</subfield>
+      <subfield code='w'>LC</subfield>
+      <subfield code='c'>1</subfield>
+      <subfield code='i'>36105210713652</subfield>
+      <subfield code='k'>STACKS</subfield>
+      <subfield code='m'>GREEN</subfield>
+      <subfield code='t'>STKS</subfield>
+    </datafield>
+  </record>
+  <!-- BIOLOGY and CHEMCHMENG in 999$m with other libraries/buildings so index but no building_facet for Biology or Chemistry/Chemical Eng-->
+  <record>
+      <leader>01801cam a2200361K  4500</leader>
+    <controlfield tag='001'>aindexMultL</controlfield>
+      <controlfield tag='008'>090724s2009    caua          100 0 eng d</controlfield>
+      <datafield ind1='0' ind2='0' tag='245'>
+        <subfield code='a'>BIOLOGY and CHEMCHMENG in 999$m with other libraries/buildings so index but no building_facet for Biology or Chemistry/Chemical Eng</subfield>
+      </datafield>
+      <datafield ind1=' ' ind2=' ' tag='999'>
+          <subfield code='a'>QB1 .A8133 V.402</subfield>
+          <subfield code='w'>LC</subfield>
+          <subfield code='c'>1</subfield>
+          <subfield code='i'>36105210713652</subfield>
+          <subfield code='k'>STACKS</subfield>
+          <subfield code='m'>BIOLOGY</subfield>
+          <subfield code='t'>STKS</subfield>
+      </datafield>
+          <datafield ind1=' ' ind2=' ' tag='999'>
+          <subfield code='a'>QB1 .A8133 V.402</subfield>
+          <subfield code='w'>LC</subfield>
+          <subfield code='c'>1</subfield>
+          <subfield code='i'>36105210713652</subfield>
+          <subfield code='k'>STACKS</subfield>
+          <subfield code='m'>CHEMCHMENG</subfield>
+          <subfield code='t'>STKS</subfield>
+      </datafield>
+      <datafield ind1=' ' ind2=' ' tag='999'>
+          <subfield code='a'>QB1 .A8133 V.402</subfield>
+          <subfield code='w'>LC</subfield>
+          <subfield code='c'>1</subfield>
+          <subfield code='i'>36105210713652</subfield>
+          <subfield code='l'>STACKS</subfield>
+          <subfield code='m'>SCIENCE</subfield>
+          <subfield code='t'>STKS</subfield>
+      </datafield>
+  </record>
 </records>

--- a/stanford-sw/test/src/edu/stanford/ClosedLibrariesTests.java
+++ b/stanford-sw/test/src/edu/stanford/ClosedLibrariesTests.java
@@ -12,7 +12,7 @@ import org.xml.sax.SAXException;
 /**
  * junit4 tests for Stanford University
  *   Remove closed libraries from the index
- * 1. if a record only has library from the closed libraries list, then do NOT index the record.
+ * 1. if a record only has library from the closed libraries list, then do NOT index the record unless it is on reserve
  * 2. if a record has multiple libraries, and one of them is from the closed libraries list, then
  *    do not assign a library facet value for the closed libraries items
  * @author Shelley Doljack
@@ -20,110 +20,134 @@ import org.xml.sax.SAXException;
 public class ClosedLibrariesTests extends AbstractStanfordTest
 {
 
-	static String testDataFname = "closedLibraries.xml";
-	String testFilePath = testDataParentPath + File.separator + testDataFname;
+  static String testDataFname = "closedLibraries.xml";
+  String testFilePath = testDataParentPath + File.separator + testDataFname;
 
-	private final String fldName = "building_facet";
-	MarcFactory factory = MarcFactory.newInstance();
+  private final String fldName = "building_facet";
+  MarcFactory factory = MarcFactory.newInstance();
 
 @Before
-	public final void setup()
-	{
-		mappingTestInit();
-	}
+  public final void setup()
+  {
+    mappingTestInit();
+  }
 
      /**
       *  Required tests based upon values in 999:
-      *  1.  Record with only a closed library does not get indexed => BIOLOGY, CHEMCHMENG, MATH-CS
-      *  2.  GREEN and STACKS => building facet, index, so item_display field exists
-      *  3.  Record with multiple libraries including a closed library in 999$m gets indexed
+      *  1. Record with only a closed library does not get indexed => BIOLOGY, CHEMCHMENG, MATH-CS
+      *  2. GREEN and STACKS => building facet, index, so item_display field exists
+      *  3. Record with multiple libraries including a closed library in 999$m gets indexed
       *       but no building facet for the closed libraries
+      *  4. Record with only a closed library but item is on reserve should get indexed
       */
 @Test
-	public void testClosedLibrariesNoBuildingFacet()
-	{
-    	// Test case #3
-		Record rec = factory.newRecord();
-		rec.setLeader(factory.newLeader("04473caa a2200313Ia 4500"));
-		ControlField cf = factory.newControlField("001", "aindexGreen");
-		rec.addVariableField(cf);
+  public void testClosedLibrariesNoBuildingFacet()
+  {
+    // Test case #3
+    Record rec = factory.newRecord();
+    rec.setLeader(factory.newLeader("04473caa a2200313Ia 4500"));
+    ControlField cf = factory.newControlField("001", "aindexGreen");
+    rec.addVariableField(cf);
 
-		DataField df999 = factory.newDataField("999", '0', '0');
-		df999.addSubfield(factory.newSubfield('a', "DO1 .A8133 V.402"));
-		df999.addSubfield(factory.newSubfield('w', "LC"));
-		df999.addSubfield(factory.newSubfield('c', "1"));
-		df999.addSubfield(factory.newSubfield('i', "36105210713652"));
-		df999.addSubfield(factory.newSubfield('l', "STACKS"));
-		df999.addSubfield(factory.newSubfield('m', "GREEN"));
-		df999.addSubfield(factory.newSubfield('t', "STKS"));
-		rec.addVariableField(df999);
+    DataField df999 = factory.newDataField("999", '0', '0');
+    df999.addSubfield(factory.newSubfield('a', "DO1 .A8133 V.402"));
+    df999.addSubfield(factory.newSubfield('w', "LC"));
+    df999.addSubfield(factory.newSubfield('c', "1"));
+    df999.addSubfield(factory.newSubfield('i', "36105210713652"));
+    df999.addSubfield(factory.newSubfield('l', "STACKS"));
+    df999.addSubfield(factory.newSubfield('m', "GREEN"));
+    df999.addSubfield(factory.newSubfield('t', "STKS"));
+    rec.addVariableField(df999);
 
-		// Building_facet value is Green
-		solrFldMapTest.assertSolrFldValue(rec, fldName, "Green");
+    // Building_facet value is Green
+    solrFldMapTest.assertSolrFldValue(rec, fldName, "Green");
 
-	    // Test case #3
-		rec = factory.newRecord();
-	    rec.setLeader(factory.newLeader("04473caa a2200313Ia 4500"));
-		cf = factory.newControlField("001", "aactualRecord");
-		rec.addVariableField(cf);
-		df999 = factory.newDataField("999", '0', '0');
-		df999.addSubfield(factory.newSubfield('a', "QB1 .A8133 V.402"));
-		df999.addSubfield(factory.newSubfield('w', "LC"));
-		df999.addSubfield(factory.newSubfield('c', "1"));
-		df999.addSubfield(factory.newSubfield('i', "36105210713652"));
-		df999.addSubfield(factory.newSubfield('l', "POP-SCI"));
-		df999.addSubfield(factory.newSubfield('m', "SCIENCE"));
-		df999.addSubfield(factory.newSubfield('t', "STKS"));
-		rec.addVariableField(df999);
+    // Test case #3
+    rec = factory.newRecord();
+    rec.setLeader(factory.newLeader("04473caa a2200313Ia 4500"));
+    cf = factory.newControlField("001", "aactualRecord");
+    rec.addVariableField(cf);
+    df999 = factory.newDataField("999", '0', '0');
+    df999.addSubfield(factory.newSubfield('a', "QB1 .A8133 V.402"));
+    df999.addSubfield(factory.newSubfield('w', "LC"));
+    df999.addSubfield(factory.newSubfield('c', "1"));
+    df999.addSubfield(factory.newSubfield('i', "36105210713652"));
+    df999.addSubfield(factory.newSubfield('l', "POP-SCI"));
+    df999.addSubfield(factory.newSubfield('m', "SCIENCE"));
+    df999.addSubfield(factory.newSubfield('t', "STKS"));
+    rec.addVariableField(df999);
 
-		df999 = factory.newDataField("999", '0', '0');
-		df999.addSubfield(factory.newSubfield('a', "DO1 .A8133 V.402"));
-		df999.addSubfield(factory.newSubfield('w', "LC"));
-		df999.addSubfield(factory.newSubfield('c', "1"));
-		df999.addSubfield(factory.newSubfield('i', "36105210713654"));
-		df999.addSubfield(factory.newSubfield('k', "STACKS"));
-		df999.addSubfield(factory.newSubfield('m', "CHEMCHMENG"));
-    	df999.addSubfield(factory.newSubfield('t', "STKS"));
-    	rec.addVariableField(df999);
+    df999 = factory.newDataField("999", '0', '0');
+    df999.addSubfield(factory.newSubfield('a', "DO1 .A8133 V.402"));
+    df999.addSubfield(factory.newSubfield('w', "LC"));
+    df999.addSubfield(factory.newSubfield('c', "1"));
+    df999.addSubfield(factory.newSubfield('i', "36105210713654"));
+    df999.addSubfield(factory.newSubfield('k', "STACKS"));
+    df999.addSubfield(factory.newSubfield('m', "CHEMCHMENG"));
+    df999.addSubfield(factory.newSubfield('t', "STKS"));
+    rec.addVariableField(df999);
 
-    	// Index but no building_facet value
-		// solrFldMapTest.assertNoSolrFld(rec,fldName);
+    // Index but no building_facet value
+    // solrFldMapTest.assertNoSolrFld(rec,fldName);
 
     // Building_facet value is Science (Li and Ma)
-		solrFldMapTest.assertSolrFldValue(rec, fldName, "Science (Li and Ma)");
+    solrFldMapTest.assertSolrFldValue(rec, fldName, "Science (Li and Ma)");
 
-		// Ignore item with library CHEMCHMENG
-		solrFldMapTest.assertSolrFldHasNoValue(rec, "barcode", "36105210713654");
-	}
+    // Ignore item with library CHEMCHMENG
+    solrFldMapTest.assertSolrFldHasNoValue(rec, "barcode", "36105210713654");
 
-	/** In order to check the exclusion of closed library items without open library items, a fresh index needs to be created so
-	 *   these tests require a test file
-	 */
+    // Test case #4
+    rec = factory.newRecord();
+    rec.setLeader(factory.newLeader("04473caa a2200313Ia 4500"));
+    cf = factory.newControlField("001", "aindexEng");
+    rec.addVariableField(cf);
+
+    df999 = factory.newDataField("999", '0', '0');
+    df999.addSubfield(factory.newSubfield('a', "QC793.3 .F5 Q53 1983"));
+    df999.addSubfield(factory.newSubfield('w', "LC"));
+    df999.addSubfield(factory.newSubfield('c', "1"));
+    df999.addSubfield(factory.newSubfield('i', "36105017547022"));
+    df999.addSubfield(factory.newSubfield('k', "ENG-RESV"));
+    df999.addSubfield(factory.newSubfield('l', "STACKS"));
+    df999.addSubfield(factory.newSubfield('m', "CHEMCHMENG"));
+    df999.addSubfield(factory.newSubfield('t', "STKS"));
+    rec.addVariableField(df999);
+
+    // Building_facet value is Engineering
+    solrFldMapTest.assertSolrFldValue(rec, fldName, "Engineering (Terman)");
+  }
+
+  /** In order to check the exclusion of closed library items without open library items, a fresh index needs to be created so
+   *   these tests require a test file
+   */
 @Test
-	public void testClosedLibrariesNotIndexed() throws ParserConfigurationException, IOException, SAXException, SolrServerException
-	{
-		// index test records
-		createFreshIx(testDataFname);
+  public void testClosedLibrariesNotIndexed() throws ParserConfigurationException, IOException, SAXException, SolrServerException
+  {
+    // index test records
+    createFreshIx(testDataFname);
 
-		// Test Case #1 Make sure record with BIOLOGY only does not get indexed
-		assertZeroResults("id", "doNotIndexBio");
+    // Test Case #1 Make sure record with BIOLOGY only does not get indexed
+    assertZeroResults("id", "doNotIndexBio");
 
-		// Test Case #1 Make sure record with CHEMCHMENG only does not get indexed
-		assertZeroResults("id", "doNotIndexChem");
+    // Test Case #1 Make sure record with CHEMCHMENG only does not get indexed
+    assertZeroResults("id", "doNotIndexChem");
 
     // Test Case #1 Make sure record with MATH-CS only does not get indexed
     assertZeroResults("id", "doNotIndexMath");
 
-		// Test Case #2 Make sure record with GREEN gets indexed
-		assertResultSize("id", "noClosedLib", 1);
+    // Test Case #2 Make sure record with GREEN gets indexed
+    assertResultSize("id", "noClosedLib", 1);
 
     // Test Case #3 Make sure record with multiple libraries including BIOLOGY and CHEMCHMENG in 999$m gets indexed
-      // but no building_facet for Biology or Chemistry/Chemical Eng
+    // but no building_facet for Biology or Chemistry/Chemical Eng
     assertResultSize("id", "indexMultL", 1);
 
-		// Make sure no records have a building_facet belonging to a closed library
-		assertZeroResults("building_facet", "Biology (Falconer)");
+    // Test Cse #4 Make sure an item on reserve at an open reserve desk but library is a closed library gets indexed
+    assertResultSize("id", "IndexEngResv", 1);
+
+    // Make sure no records have a building_facet belonging to a closed library
+    assertZeroResults("building_facet", "Biology (Falconer)");
     assertZeroResults("building_facet", "Chemistry & ChemEng (Swain)");
     assertZeroResults("building_facet", "Math & Statistics");
-	}
+  }
 }

--- a/stanford-sw/translation_maps/library_map.properties
+++ b/stanford-sw/translation_maps/library_map.properties
@@ -40,3 +40,21 @@ SPEC-COLL = Special Collections
 TANNER = Philosophy (Tanner)
 
 #SUL = Stanford University Libraries
+
+
+# Map reserve locations to library for indexing
+
+ART-RESV = Art & Architecture (Bowes)
+BUS-RESV = Business
+EARTH-RESV = Earth Sciences (Branner)
+EAS-RESV = East Asia
+EDU-RESV = Education (Cubberley)
+ENG-RESV = Engineering (Terman)
+GREEN-RESV = Green
+HOOV-RESV = Hoover Library
+HOP-RESV = Marine Biology (Miller)
+LAW-RESV = Law (Crown)
+MEDIA-RESV = Media & Microtext Center
+MUSIC-RESV = Music
+SCI-RESV = Science (Li and Ma)
+TANN-RESV = Philosophy (Tanner)

--- a/stanford-sw/translation_maps/locations_reserves_list.properties
+++ b/stanford-sw/translation_maps/locations_reserves_list.properties
@@ -1,0 +1,17 @@
+# reserve locations implying that the item should be indexed
+
+ART-RESV      # Art Reserves
+BUS-RESV      # Business Reserves
+EARTH-RESV    # Branner Reserves
+EAS-RESV      # EastAsia Reserves
+EDU-RESV      # Cubberley Reserves
+ENG-RESV      # Engineering Reserves
+GREEN-RESV    # Green Reserves
+HOOV-RESV     # Hoover Reserves
+HOP-RESV      # Miller Reserves
+LAW-RESV      # Law Reserves
+MEDIA-RESV    # Media Reserves
+MEYER-RESV    # Meyer Reserves
+MUSIC-RESV    # Music Reserves
+SCI-RESV      # Science Reserves
+TANN-RESV     # Tanner Reserves


### PR DESCRIPTION
@ndushay This is a last minute PR before doing the full re-index next week. Typically records on reserve at a different library than the item library are indexed at the reserve library. This rule also needs to apply to records that have an item library in the closed library list but are on reserve. For "live" data you can check these records: https://searchworks-morison.stanford.edu/view/5377072, https://searchworks-morison.stanford.edu/view/4739061.  