### PR TITLE
Changes Symphony production server name.

### DIFF
--- a/stanford-sw/scripts/getBodoniFullDump.sh
+++ b/stanford-sw/scripts/getBodoniFullDump.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 # getBodoniFullDump.sh
-# Pull over the latest full dump from Sirsi bodoni-local
+# Pull over the latest full dump from Sirsi bodoni
 #  Naomi Dushay 2008-10-12
 
 COUNTS_FNAME=files_counts
@@ -10,19 +10,19 @@ LOCAL_DATA_DIR=/data/sirsi
 LATEST_DATA_DIR=$LOCAL_DATA_DIR/latest
 PREVIOUS_DATA_DIR=$LOCAL_DATA_DIR/previous
 
-# check if dump is on bodoni-local
+# check if dump is on bodoni
 
 # grab remote files_counts
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
 
 
 # ***** TODO:  THIS DIFF CONDITIONAL DOESN'T WORK!!!!  ******
- 
+
 # check if new file counts match latest local file counts
 #if [`diff $LOCAL_DATA_DIR/$COUNTS_FNAME $LATEST_DATA_DIR/$COUNTS_FNAME` -eq 0]
 `diff -q $LOCAL_DATA_DIR/$COUNTS_FNAME $LATEST_DATA_DIR/$COUNTS_FNAME` >/dev/null 2>&1
 if [ $? -eq 0]
-then 
+then
   echo " Local sirsi dump is up to date"
   exit 0
 fi
@@ -49,6 +49,6 @@ mv $LATEST_DATA_DIR/logs/* $PREVIOUS_DATA_DIR/logs
 
 
 #  scp remote files to "latest" preserving timestamps
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/* $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/* $LATEST_DATA_DIR/
 
 exit 0

--- a/stanford-sw/scripts/getBodoniHourly.sh
+++ b/stanford-sw/scripts/getBodoniHourly.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 # getBodoniHourly.sh
-# Pull over the latest partial day update files from Sirsi bodoni-local
+# Pull over the latest partial day update files from Sirsi bodoni
 #  Naomi Dushay 2010-01-08
 
 REMOTE_DATA_DIR=/s/SUL/Dataload/SearchworksPartday/Output
@@ -14,8 +14,8 @@ DEL_KEYS_FNAME="ckeys_delete.del"
 RECORDS_FNAME="uni_partday.marc"
     
 #  sftp remote files with today's datestamp to "latest/updates"
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
 
 exit 0

--- a/stanford-sw/scripts/getBodoniNightly.sh
+++ b/stanford-sw/scripts/getBodoniNightly.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 # getBodoniNightly.sh
-# Pull the nightly update files from Sirsi bodoni-local
+# Pull the nightly update files from Sirsi bodoni
 # defaults to most recent; can take a date arg in the form yymmdd
 #  Naomi Dushay 2010-01-08
 

--- a/stanford-sw/scripts/getBodoniNightlyAll.sh
+++ b/stanford-sw/scripts/getBodoniNightlyAll.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 # getBodoniNightlyAll.sh
-# Pull over all the incremental update files from Sirsi bodoni-local
+# Pull over all the incremental update files from Sirsi bodoni
 #  Naomi Dushay 2010-03-13
 
 REMOTE_DATA_DIR=/s/SUL/Dataload/SearchWorksIncrement/Output
@@ -9,6 +9,6 @@ LOCAL_DATA_DIR=/data/sirsi
 LATEST_DATA_DIR=$LOCAL_DATA_DIR/latest/updates
 
 #  scp remote files preserving timestamps
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/* $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/* $LATEST_DATA_DIR/
 
 exit 0

--- a/stanford-sw/scripts/indexManyNightlyNoEmail.sh
+++ b/stanford-sw/scripts/indexManyNightlyNoEmail.sh
@@ -11,5 +11,5 @@ LANG="en_US.UTF-8"
 export LANG
 (source /usr/local/rvm/scripts/rvm && cd /home/blacklight/crez-sw-ingest && ./bin/index_latest_no_email.sh -s prod )
 
-echo "!!! RUN GDOR, SEARCHWORKS TESTS before putting index into production !!!"
+echo "!!! RUN SEARCHWORKS TESTS before putting index into production !!!"
 echo "!!! CHGRP before putting index into production !!!"

--- a/stanford-sw/scripts/pullThenIndexBodoniHourly.sh
+++ b/stanford-sw/scripts/pullThenIndexBodoniHourly.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 # pullThenIndexBodoniHourlyNoEmail.sh
-# Pull over the latest partial day update files from Sirsi bodoni-local, then
+# Pull over the latest partial day update files from Sirsi bodoni, then
 #  Remove deleted records (per file of ids) from index and update index (with marc records in file)
 #
 # updated for Naomi's FORK of solrmarc 2011-01-23
@@ -16,9 +16,9 @@ DEL_KEYS_FNAME="ckeys_delete.del"
 RECORDS_FNAME="uni_partday.marc"
 
 # sftp remote files to "latest/updates"
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
 
 
 #########

--- a/stanford-sw/scripts/pullThenIndexBodoniHourlyNoEmail.sh
+++ b/stanford-sw/scripts/pullThenIndexBodoniHourlyNoEmail.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 # pullThenIndexBodoniHourlyNoEmail.sh
-# Pull over the latest partial day update files from Sirsi bodoni-local, then
+# Pull over the latest partial day update files from Sirsi bodoni, then
 #  Remove deleted records (per file of ids) from index and update index (with marc records in file)
 #
 # updated for Naomi's FORK of solrmarc 2011-01-23
@@ -16,9 +16,9 @@ DEL_KEYS_FNAME="ckeys_delete.del"
 RECORDS_FNAME="uni_partday.marc"
 
 # sftp remote files to "latest/updates"
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
 
 
 #########

--- a/stanford-sw/scripts/pullThenIndexBodoniHourlyNoEmailNoCrez.sh
+++ b/stanford-sw/scripts/pullThenIndexBodoniHourlyNoEmailNoCrez.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 # pullThenIndexBodoniHourlyNoEmailNoCrez.sh
-# Pull over the latest partial day update files from Sirsi bodoni-local, then
+# Pull over the latest partial day update files from Sirsi bodoni, then
 #  Remove deleted records (per file of ids) from index and update index (with marc records in file)
 #
 # updated for Naomi's FORK of solrmarc 2011-01-23
@@ -16,9 +16,9 @@ DEL_KEYS_FNAME="ckeys_delete.del"
 RECORDS_FNAME="uni_partday.marc"
 
 # sftp remote files to "latest/updates"
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
 
 
 #########

--- a/stanford-sw/scripts/pullThenIndexBodoniHourlyNoEmailNoPullCrez.sh
+++ b/stanford-sw/scripts/pullThenIndexBodoniHourlyNoEmailNoPullCrez.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 # pullThenIndexBodoniHourlyNoEmail.sh
-# Pull over the latest partial day update files from Sirsi bodoni-local, then
+# Pull over the latest partial day update files from Sirsi bodoni, then
 #  Remove deleted records (per file of ids) from index and update index (with marc records in file)
 #
 # updated for Naomi's FORK of solrmarc 2011-01-23
@@ -16,9 +16,9 @@ DEL_KEYS_FNAME="ckeys_delete.del"
 RECORDS_FNAME="uni_partday.marc"
 
 # sftp remote files to "latest/updates"
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
 
 
 #########

--- a/stanford-sw/scripts/pullThenIndexBodoniNightly.sh
+++ b/stanford-sw/scripts/pullThenIndexBodoniNightly.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 # pullThenIndexBodoniNightly.sh
-# Pull over nightly update files from Sirsi bodoni-local, then
+# Pull over nightly update files from Sirsi bodoni, then
 #  Remove deleted records (per file of ids) from index and update index (with marc records in file)
 # defaults to most recent; can take a date arg in the form yymmdd
 #
@@ -25,9 +25,9 @@ else
 fi
 
 # sftp remote files with datestamp to "latest/updates"
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
 
 
 #########

--- a/stanford-sw/scripts/pullThenIndexBodoniNightlyNoEmailNoCrez.sh
+++ b/stanford-sw/scripts/pullThenIndexBodoniNightlyNoEmailNoCrez.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 # pullThenIndexBodoniNightlyNoEmailNoCrez.sh
-# Pull over nightly update files from bodoni-local Sirsi, then
+# Pull over nightly update files from bodoni Sirsi, then
 #  Remove deleted records (per file of ids) from index and update index (with marc records in file)
 # defaults to most recent; can take a date arg in the form yymmdd
 #
@@ -25,9 +25,9 @@ else
 fi
 
 # sftp remote files with datestamp to "latest/updates"
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
 
 
 #########

--- a/stanford-sw/scripts/pullThenIndexBodoniNightlyNoEmailNoCrezNoCommit.sh
+++ b/stanford-sw/scripts/pullThenIndexBodoniNightlyNoEmailNoCrezNoCommit.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 # pullThenIndexBodoniNightlyNoEmailNoCrezNoCommit.sh
-# Pull over nightly update files from bodoni-local Sirsi, then
+# Pull over nightly update files from bodoni Sirsi, then
 #  Remove deleted records (per file of ids) from index and update index (with marc records in file)
 # defaults to most recent; can take a date arg in the form yymmdd
 #
@@ -25,9 +25,9 @@ else
 fi
 
 # sftp remote files with datestamp to "latest/updates"
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
 
 
 #########

--- a/stanford-sw/scripts/pullThenIndexBodoniNightlyOpt.sh
+++ b/stanford-sw/scripts/pullThenIndexBodoniNightlyOpt.sh
@@ -25,9 +25,9 @@ else
 fi
 
 # sftp remote files with datestamp to "latest/updates"
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
 
 
 #########

--- a/stanford-sw/scripts/pullThenIndexSirsiIncr.sh
+++ b/stanford-sw/scripts/pullThenIndexSirsiIncr.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 # pullThenIndexSirsiIncr.sh
 # NOTE:  this is deprecated and will be replaced by pullThenIndexBodoniNightly.sh
-# Pull over nightly update files from Sirsi bodoni-local, then
+# Pull over nightly update files from Sirsi bodoni, then
 #  Remove deleted records (per file of ids) from index and update index (with marc records in file)
 # defaults to most recent; can take a date arg in the form yymmdd
 #
@@ -26,9 +26,9 @@ else
 fi
 
 #  sftp remote files with datestamp to "latest/updates"
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
-sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni-local:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$COUNTS_FNAME $LOCAL_DATA_DIR
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$DEL_KEYS_FNAME $LATEST_DATA_DIR/
+sftp -o 'IdentityFile=~/.ssh/id_rsa' sirsi@bodoni:$REMOTE_DATA_DIR/$RECORDS_FNAME $LATEST_DATA_DIR/
 
 
 #########


### PR DESCRIPTION
Fixes #153 
The new Symphony server will be renamed to bodoni when it is put into
production. In order for the pullThenIndex* scripts to work, they should
be getting data from bodoni and not bodoni-local. Using bodoni-local was
put in place during the last Symphony server migration and is no longer
needed.